### PR TITLE
Memory Allocator and Smart Pointers (not used everywhere)

### DIFF
--- a/sources/code/Common/Memory/Allocators.hpp
+++ b/sources/code/Common/Memory/Allocators.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "Allocators/DynamicAllocator.hpp"
+#include "Allocators/LinearAllocator.hpp"
+#include "Allocators/StackAllocator.hpp"

--- a/sources/code/Common/Memory/Allocators.hpp
+++ b/sources/code/Common/Memory/Allocators.hpp
@@ -3,3 +3,4 @@
 #include "Allocators/DynamicAllocator.hpp"
 #include "Allocators/LinearAllocator.hpp"
 #include "Allocators/StackAllocator.hpp"
+#include "Allocators/PoolAllocator.hpp"

--- a/sources/code/Common/Memory/Allocators/DynamicAllocator.cpp
+++ b/sources/code/Common/Memory/Allocators/DynamicAllocator.cpp
@@ -51,6 +51,12 @@ bool DynamicAllocator::Initialize(size_t size) {
 	return true;
 }
 
+DynamicAllocator::~DynamicAllocator() {
+	if (rootHeader && hasAllocatedOwnMemory) {
+		delete rootHeader;
+	}
+}
+
 size_t DynamicAllocator::GetUsedSize() const {
 	return usedSize;
 }

--- a/sources/code/Common/Memory/Allocators/DynamicAllocator.cpp
+++ b/sources/code/Common/Memory/Allocators/DynamicAllocator.cpp
@@ -1,0 +1,239 @@
+#include <memory>
+#include <iostream>
+#include <sstream>
+
+#include "DynamicAllocator.hpp"
+
+using namespace Grindstone::Memory::Allocators;
+
+// https://www.gingerbill.org/article/2021/11/30/memory-allocation-strategies-005/
+
+constexpr size_t headerSize = sizeof(DynamicAllocator::Header);
+
+std::string BreakBytes(size_t bytes) {
+	if (bytes == 0) {
+		return "0b";
+	}
+
+	size_t gb = bytes >> 30;
+	size_t totalMb = bytes >> 20;
+	size_t totalKb = bytes >> 10;
+
+	size_t mb = (bytes >> 20) - (gb << 10);
+	size_t kb = (bytes >> 10) - (totalMb << 10);
+	size_t b = bytes - (totalKb << 10);
+
+	std::stringstream str;
+
+	if (gb > 0) {
+		str << gb << "gb ";
+	}
+
+	if (mb > 0) {
+		str << mb << "mb ";
+	}
+
+	if (kb > 0) {
+		str << kb << "kb ";
+	}
+
+	if (b > 0) {
+		str << b << "b ";
+	}
+
+	return str.str();
+}
+
+void DynamicAllocator::Initialize(void* ownedMemory, size_t size) {
+	rootHeader = reinterpret_cast<Header*>(ownedMemory);
+	if (rootHeader == nullptr) {
+		return;
+	}
+
+	memset(rootHeader, 0, size);
+	usedSize = sizeof(Header);
+	totalMemorySize = size;
+	hasAllocatedOwnMemory = false;
+
+	rootHeader->nextHeader = nullptr;
+	rootHeader->previousHeader = nullptr;
+	rootHeader->isAllocated = false;
+}
+
+bool DynamicAllocator::Initialize(size_t size) {
+	rootHeader = reinterpret_cast<Header*>(malloc(size));
+	if (rootHeader == nullptr) {
+		return false;
+	}
+
+	memset(rootHeader, 0, size);
+	usedSize = sizeof(Header);
+	totalMemorySize = size;
+	hasAllocatedOwnMemory = true;
+
+	rootHeader->nextHeader = nullptr;
+	rootHeader->previousHeader = nullptr;
+	rootHeader->isAllocated = false;
+	return true;
+}
+
+size_t DynamicAllocator::GetUsedSize() const {
+	return usedSize;
+}
+
+void* DynamicAllocator::GetMemory() const {
+	return rootHeader;
+}
+
+size_t DynamicAllocator::GetTotalMemorySize() const {
+	return totalMemorySize;
+}
+
+DynamicAllocator::Header* DynamicAllocator::FindAvailableHeader(size_t size) const {
+	size_t minimumSpaceRequired = size + sizeof(Header);
+	Header* currentMemoryHeader = rootHeader;
+	Header* previousMemoryHeader = nullptr;
+
+	while (true) {
+		Header* nextMemoryHeader = currentMemoryHeader->nextHeader;
+		char* endOfBlock = reinterpret_cast<char*>(nextMemoryHeader);
+		size_t spaceLeft = endOfBlock - reinterpret_cast<char*>(currentMemoryHeader);
+
+		if (!currentMemoryHeader->isAllocated && spaceLeft >= minimumSpaceRequired) {
+			return currentMemoryHeader;
+		}
+
+		if (currentMemoryHeader->nextHeader == nullptr) {
+			break;
+		}
+
+		currentMemoryHeader = currentMemoryHeader->nextHeader;
+	}
+
+	char* end = reinterpret_cast<char*>(rootHeader) + totalMemorySize;
+	size_t spaceLeft = end - reinterpret_cast<char*>(currentMemoryHeader);
+
+	if (!currentMemoryHeader->isAllocated && spaceLeft >= minimumSpaceRequired) {
+		return currentMemoryHeader;
+	}
+
+	return nullptr;
+}
+
+void* DynamicAllocator::Allocate(size_t size) {
+	DynamicAllocator::Header* header = FindAvailableHeader(size);
+
+	if (header == nullptr) {
+		return nullptr;
+	}
+
+	char* blockPointer = reinterpret_cast<char*>(header) + sizeof(Header);
+
+	char* nextHeaderAsChar = blockPointer + size;
+	char* tail = reinterpret_cast<char*>(rootHeader) + totalMemorySize;
+	if (nextHeaderAsChar + sizeof(Header) <= tail) {
+		Header* nextHeader = reinterpret_cast<Header*>(nextHeaderAsChar);
+		header->nextHeader = nextHeader;
+		nextHeader->nextHeader = nullptr;
+		nextHeader->previousHeader = header;
+
+		usedSize += size + headerSize;
+	}
+	else {
+		header->nextHeader = nullptr;
+		usedSize += size;
+	}
+
+	header->isAllocated = true;
+
+	return blockPointer;
+}
+
+DynamicAllocator::Header* DynamicAllocator::GetHeaderOfBlock(void* block) {
+	char* blockPtrAsChar = static_cast<char*>(block);
+	Header* headerPtr = reinterpret_cast<Header*>(blockPtrAsChar - sizeof(Header));
+
+	return headerPtr;
+}
+
+bool DynamicAllocator::Free(void* memPtr, bool shouldClear) {
+	if (memPtr == nullptr) {
+		return false;
+	}
+
+	Header* header = GetHeaderOfBlock(memPtr);
+
+	if (header == nullptr) {
+		return false;
+	}
+
+	header->isAllocated = false;
+
+	Header* prevHeader = header;
+	if (header->previousHeader != nullptr && !header->previousHeader->isAllocated) {
+		prevHeader = header->previousHeader;
+	}
+
+	Header* nextHeader = header->nextHeader;
+	if (nextHeader != nullptr && !nextHeader->isAllocated) {
+		nextHeader = nextHeader->nextHeader;
+	}
+
+	prevHeader->nextHeader = nextHeader;
+	if (nextHeader != nullptr) {
+		nextHeader->previousHeader = prevHeader;
+	}
+
+	char* clearStart = reinterpret_cast<char*>(header);
+	char* clearEnd = header->nextHeader == nullptr
+		? reinterpret_cast<char*>(rootHeader) + totalMemorySize
+		: reinterpret_cast<char*>(header->nextHeader);
+
+	size_t size = clearEnd - clearStart;
+
+	// TODO: This isn't right
+	usedSize -= size;
+
+	if (shouldClear) {
+		memset(clearStart, 0, size);
+	}
+
+	return true;
+}
+
+void DynamicAllocator::PrintBlocks() {
+	Header* currentHeader = rootHeader;
+	while (currentHeader != nullptr) {
+		const char* allocStr = currentHeader->isAllocated ? "ALLOCATED" : "DEALLOCATED";
+
+		char* target = currentHeader->nextHeader == nullptr
+			? reinterpret_cast<char*>(rootHeader) + totalMemorySize
+			: reinterpret_cast<char*>(currentHeader->nextHeader);
+
+		size_t bytes = target - reinterpret_cast<char*>(currentHeader) - sizeof(Header);
+		std::cout << "[" << allocStr << "]:" << BreakBytes(bytes) << "\n";
+		currentHeader = currentHeader->nextHeader;
+	}
+}
+
+void* ValidatePtr(void* block) {
+	using Grindstone::Memory::Allocators::DynamicAllocator;
+	if (block == nullptr) {
+		return nullptr;
+	}
+
+	DynamicAllocator::Header* header = DynamicAllocator::GetHeaderOfBlock(block);
+	return header->isAllocated
+		? block
+		: nullptr;
+}
+
+bool IsValid(void* block) {
+	using Grindstone::Memory::Allocators::DynamicAllocator;
+	if (block == nullptr) {
+		return false;
+	}
+
+	DynamicAllocator::Header* header = DynamicAllocator::GetHeaderOfBlock(block);
+	return header->isAllocated;
+}

--- a/sources/code/Common/Memory/Allocators/DynamicAllocator.hpp
+++ b/sources/code/Common/Memory/Allocators/DynamicAllocator.hpp
@@ -28,6 +28,8 @@ namespace Grindstone::Memory::Allocators {
 
 		void PrintBlocks();
 
+		bool IsEmpty() const;
+
 		size_t GetTotalMemorySize() const;
 		size_t GetUsedSize() const;
 		void* GetMemory() const;

--- a/sources/code/Common/Memory/Allocators/DynamicAllocator.hpp
+++ b/sources/code/Common/Memory/Allocators/DynamicAllocator.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <string>
+#include <stdint.h>
+#include <utility>
+
+namespace Grindstone::Memory::Allocators {
+	/**
+	 * \brief A dynamic allocator represented by a linked list.
+	 *
+	 * Memory in a dynamic allocator can be allocated and deallocated freely, with no restrictions.
+	 * Allocations have a header that points to the next block of memory, and so free memory can be found
+	 * in between allocated blocks of memory.
+	 */
+	class DynamicAllocator {
+	public:
+		struct Header {
+			bool isAllocated;
+			Header* nextHeader;
+			Header* previousHeader;
+		};
+
+		void Initialize(void* ownedMemory, size_t size);
+		bool Initialize(size_t size);
+
+		void* Allocate(size_t size);
+		bool Free(void* memPtr, bool shouldClear = false);
+
+		void PrintBlocks();
+
+		size_t GetTotalMemorySize() const;
+		size_t GetUsedSize() const;
+		void* GetMemory() const;
+
+		// Assumes that this is a header within the memory block, in order to be more optimal
+		static Header* GetHeaderOfBlock(void* block);
+
+		template<typename T, typename... Args>
+		T* Allocate(Args&&... params) {
+			T* ptr = static_cast<T*>(Allocate(sizeof(T)));
+			if (ptr != nullptr) {
+				// Call the constructor on the newly allocated memory
+				new (ptr) T(std::forward<Args>(params)...);
+			}
+
+			return ptr;
+		}
+
+		template<typename T>
+		T* AllocateWithoutConstructor() {
+			return static_cast<T*>(Allocate(sizeof(T)));
+		}
+
+		template<typename T>
+		bool Free(void* memPtr, bool shouldClear = false) {
+			bool retVal = Free(memPtr, shouldClear);
+			if (retVal) {
+				reinterpret_cast<T*>(memPtr)->~T();
+				return true;
+			}
+
+			return false;
+		}
+
+	private:
+		Header* FindAvailableHeader(size_t size) const;
+
+		Header* rootHeader = nullptr;
+		size_t totalMemorySize = 0;
+		size_t usedSize = 0;
+		bool hasAllocatedOwnMemory = false;
+	};
+}
+
+std::string BreakBytes(size_t bytes);
+
+void* ValidatePtr(void* block);
+bool IsValid(void* block);

--- a/sources/code/Common/Memory/Allocators/DynamicAllocator.hpp
+++ b/sources/code/Common/Memory/Allocators/DynamicAllocator.hpp
@@ -23,6 +23,8 @@ namespace Grindstone::Memory::Allocators {
 			Header* previousHeader;
 		};
 
+		~DynamicAllocator();
+
 		void Initialize(void* ownedMemory, size_t size);
 		bool Initialize(size_t size);
 

--- a/sources/code/Common/Memory/Allocators/LinearAllocator.cpp
+++ b/sources/code/Common/Memory/Allocators/LinearAllocator.cpp
@@ -1,5 +1,6 @@
 #include <memory>
 
+#include "../../Assert.hpp"
 #include "LinearAllocator.hpp"
 
 using namespace Grindstone::Allocators;
@@ -23,14 +24,16 @@ bool LinearAllocator::Initialize(size_t size) {
 }
 
 void* LinearAllocator::Allocate(size_t size) {
+#ifdef _DEBUG
 	if (memory == nullptr) {
-		// TODO: Assert
+		GS_BREAK_WITH_MESSAGE("No memory buffer allocated.");
 		return nullptr;
 	}
+#endif
 
 	size_t usedSizeAfterAllocation = usedSize + size;
 	if (usedSizeAfterAllocation > totalMemorySize) {
-		// TODO: Assert
+		GS_BREAK_WITH_MESSAGE("Cannot allocate memory.");
 		return nullptr;
 	}
 

--- a/sources/code/Common/Memory/Allocators/LinearAllocator.cpp
+++ b/sources/code/Common/Memory/Allocators/LinearAllocator.cpp
@@ -1,0 +1,59 @@
+#include <memory>
+
+#include "LinearAllocator.hpp"
+
+using namespace Grindstone::Allocators;
+
+LinearAllocator::~LinearAllocator() {
+	Destroy();
+}
+
+void LinearAllocator::Initialize(void* ownedMemory, size_t size) {
+	memory = ownedMemory;
+	totalMemorySize = size;
+	hasAllocatedOwnMemory = false;
+}
+
+bool LinearAllocator::Initialize(size_t size) {
+	memory = malloc(size);
+	totalMemorySize = size;
+	hasAllocatedOwnMemory = true;
+
+	return memory != nullptr;
+}
+
+void* LinearAllocator::Allocate(size_t size) {
+	if (memory == nullptr) {
+		// TODO: Assert
+		return nullptr;
+	}
+
+	size_t usedSizeAfterAllocation = usedSize + size;
+	if (usedSizeAfterAllocation > totalMemorySize) {
+		// TODO: Assert
+		return nullptr;
+	}
+
+	void* block = static_cast<char*>(memory) + usedSize;
+	usedSize = usedSizeAfterAllocation;
+
+	return block;
+}
+
+void LinearAllocator::Destroy() {
+	if (hasAllocatedOwnMemory && memory != nullptr) {
+		delete memory;
+	}
+}
+
+void LinearAllocator::Clear() {
+	usedSize = 0;
+}
+
+void LinearAllocator::ClearAndZero() {
+	if (memory != nullptr) {
+		memset(memory, 0, totalMemorySize);
+	}
+
+	usedSize = 0;
+}

--- a/sources/code/Common/Memory/Allocators/LinearAllocator.hpp
+++ b/sources/code/Common/Memory/Allocators/LinearAllocator.hpp
@@ -4,7 +4,7 @@
 
 namespace Grindstone::Allocators {
 	/**
-	 * \brief A linear allocator where memory can only be deallocated when freed.
+	 * \brief A linear allocator where memory can only be deallocated when the entire allocator is cleared.
 	 *
 	 * Memory in a linear allocator is allocated sequentially, similar to a StackAllocator,
 	 * one after the other. This removes the possibility of fragmentation, but with LinearAllocators

--- a/sources/code/Common/Memory/Allocators/LinearAllocator.hpp
+++ b/sources/code/Common/Memory/Allocators/LinearAllocator.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace Grindstone::Allocators {
+	/**
+	 * \brief A linear allocator where memory can only be deallocated when freed.
+	 *
+	 * Memory in a linear allocator is allocated sequentially, similar to a StackAllocator,
+	 * one after the other. This removes the possibility of fragmentation, but with LinearAllocators
+	 * specifically, they are never deallocated. Also known as an arena allocator.
+	 */
+	class LinearAllocator {
+	public:
+		~LinearAllocator();
+
+		void Initialize(void* ownedMemory, size_t size);
+		bool Initialize(size_t size);
+		void* Allocate(size_t size);
+		void Clear();
+		void ClearAndZero();
+		void Destroy();
+
+		template<typename T, typename... Args>
+		T* Allocate(Args&&... params) {
+			T* ptr = static_cast<T*>(Allocate(sizeof(T)));
+			if (ptr != nullptr) {
+				// Call the constructor on the newly allocated memory
+				new (ptr) T(std::forward<Args>(params)...);
+			}
+
+			return ptr;
+		}
+
+		template<typename T>
+		T* AllocateWithoutConstructor() {
+			return static_cast<T*>(Allocate(sizeof(T)));
+		}
+
+	private:
+		size_t totalMemorySize;
+		size_t usedSize;
+
+		void* memory;
+		bool hasAllocatedOwnMemory;
+	};
+}

--- a/sources/code/Common/Memory/Allocators/PoolAllocator.cpp
+++ b/sources/code/Common/Memory/Allocators/PoolAllocator.cpp
@@ -1,0 +1,123 @@
+#include "../../Assert.hpp"
+#include "PoolAllocator.hpp"
+
+using namespace Grindstone::Allocators;
+
+// ============================================
+// Base Allocator Methods
+// ============================================
+
+void BasePoolAllocator::Clear() {
+	usedChunkCount = 0;
+}
+
+void BasePoolAllocator::ClearAndZero() {
+	if (memory != nullptr) {
+		memset(memory, 0, totalMemorySize);
+	}
+
+	usedChunkCount = 0;
+}
+
+void BasePoolAllocator::Destroy() {
+	if (hasAllocatedOwnMemory && memory != nullptr) {
+		delete memory;
+	}
+}
+
+void* BasePoolAllocator::AllocateImpl() {
+#ifdef _DEBUG
+	if (memory == nullptr) {
+		GS_BREAK_WITH_MESSAGE("No memory buffer allocated.");
+		return nullptr;
+	}
+#endif
+
+	if (headFreePtr == nullptr || usedChunkCount >= totalChunkCount) {
+		GS_BREAK_WITH_MESSAGE("Cannot allocate memory, pool is full.");
+		return nullptr;
+	}
+
+	void* returnedChunk = headFreePtr;
+	headFreePtr = headFreePtr->next;
+	++usedChunkCount;
+	
+	return returnedChunk;
+}
+
+void BasePoolAllocator::DeallocateImpl(void* ptr) {
+	--usedChunkCount;
+	
+	reinterpret_cast<FreeLink*>(ptr)->next = headFreePtr;
+	headFreePtr = reinterpret_cast<FreeLink*>(ptr);
+
+#ifdef _DEBUG
+	memset(reinterpret_cast<char*>(ptr) + sizeof(FreeLink), 0xcd, chunkSize - sizeof(FreeLink));
+#endif
+}
+
+void BasePoolAllocator::DeallocateImpl(size_t index) {
+	size_t chunkOffset = index * chunkSize;
+	DeallocateImpl(reinterpret_cast<char*>(memory) + chunkOffset);
+}
+
+void BasePoolAllocator::SetupLinkedList() {
+#ifdef _DEBUG
+	memset(memory, 0xcd, totalMemorySize);
+#endif
+
+	FreeLink* chunk = static_cast<FreeLink*>(memory);
+	headFreePtr = chunk;
+
+	for (size_t i = 0; i < totalChunkCount - 1; ++i) {
+		chunk->next = reinterpret_cast<FreeLink*>(reinterpret_cast<char*>(chunk) + chunkSize);
+		chunk = chunk->next;
+	}
+
+	chunk->next = nullptr;
+}
+
+
+bool BasePoolAllocator::IsEmpty() const {
+	return usedChunkCount == 0;
+}
+
+size_t BasePoolAllocator::GetUsedCount() const {
+	return usedChunkCount;
+}
+
+// ============================================
+// Generic Allocator Methods
+// ============================================
+
+GenericPoolAllocator::~GenericPoolAllocator() {
+	Destroy();
+}
+
+void GenericPoolAllocator::Initialize(void* ownedMemory, size_t totalSize, size_t sizePerChunk) {
+	memory = ownedMemory;
+	totalMemorySize = totalSize;
+	chunkSize = sizePerChunk;
+	usedChunkCount = 0;
+	totalChunkCount = totalSize / sizePerChunk;
+	hasAllocatedOwnMemory = false;
+
+	SetupLinkedList();
+}
+
+bool GenericPoolAllocator::Initialize(size_t sizePerChunk, size_t maxChunkCount) {
+	totalMemorySize = sizePerChunk * maxChunkCount;
+	totalChunkCount = maxChunkCount;
+	chunkSize = sizePerChunk;
+	usedChunkCount = 0;
+	memory = malloc(totalMemorySize);
+	hasAllocatedOwnMemory = true;
+
+	SetupLinkedList();
+
+	return memory != nullptr;
+}
+
+void* GenericPoolAllocator::Allocate() {
+	return AllocateImpl();
+}

--- a/sources/code/Common/Memory/Allocators/PoolAllocator.hpp
+++ b/sources/code/Common/Memory/Allocators/PoolAllocator.hpp
@@ -1,0 +1,170 @@
+#pragma once
+
+#include <stdint.h>
+#include <utility>
+#include <functional>
+#include <memory>
+
+#include "../SmartPointers.hpp"
+
+namespace Grindstone::Allocators {
+	class BasePoolAllocator {
+	public:
+
+		void Clear();
+		void ClearAndZero();
+		void Destroy();
+
+		bool IsEmpty() const;
+		size_t GetUsedCount() const;
+
+		struct FreeLink {
+			FreeLink* next;
+		};
+
+	protected:
+		BasePoolAllocator() = default;
+
+		inline void* AllocateImpl();
+		inline void SetupLinkedList();
+
+		void DeallocateImpl(size_t index);
+		void DeallocateImpl(void* ptr);
+
+		// Total Memory size is used in case we are passed owned memory that is bigger than totalChunkCount * chunkSize
+		size_t totalMemorySize = 0;
+		size_t chunkSize = 0;
+		size_t usedChunkCount = 0;
+		size_t totalChunkCount = 0;
+
+		FreeLink* headFreePtr = nullptr;
+		void* memory = nullptr;
+		bool hasAllocatedOwnMemory = false;
+		std::function<void(void*)> deleteFn;
+	};
+
+	/**
+	 * \brief A generic pool allocator where all allocations have up to a certain chunk size.
+	 *
+	 * Memory in a linear allocator is allocated sequentially, similar to a StackAllocator,
+	 * one after the other. This removes the possibility of fragmentation, but with LinearAllocators
+	 * specifically, they are never deallocated. Also known as an arena allocator.
+	 */
+	class GenericPoolAllocator : public BasePoolAllocator {
+	public:
+		GenericPoolAllocator() = default;
+		~GenericPoolAllocator();
+
+		void Initialize(void* ownedMemory, size_t totalSize, size_t sizePerChunk);
+		bool Initialize(size_t sizePerChunk, size_t maxChunkCount);
+		void* Allocate();
+		void Deallocate(size_t index);
+		void Deallocate(void* ptr);
+
+	};
+
+	/**
+	 * \brief A typed pool allocator where all allocations are the size of the type T.
+	 *
+	 * Memory in a linear allocator is allocated sequentially, similar to a StackAllocator,
+	 * one after the other. This removes the possibility of fragmentation, but with LinearAllocators
+	 * specifically, they are never deallocated. Also known as an arena allocator.
+	 */
+	template <typename T>
+	class PoolAllocator : public BasePoolAllocator {
+	public:
+		PoolAllocator() = default;
+
+		bool Initialize(void* ownedMemory, size_t totalSize) {
+			memory = ownedMemory;
+			totalMemorySize = totalSize;
+			chunkSize = sizeof(T);
+			usedChunkCount = 0;
+			totalChunkCount = totalSize / chunkSize;
+			hasAllocatedOwnMemory = false;
+
+			deleteFn = [this](void* ptr) -> void {
+				DeallocateImpl(ptr);
+			};
+
+			SetupLinkedList();
+		}
+
+		bool Initialize(size_t maxChunkCount) {
+			chunkSize = sizeof(T);
+			totalMemorySize = chunkSize * maxChunkCount;
+			usedChunkCount = 0;
+			totalChunkCount = maxChunkCount;
+
+			memory = malloc(totalMemorySize);
+			hasAllocatedOwnMemory = true;
+
+			SetupLinkedList();
+
+			deleteFn = [this](void* ptr) -> void {
+				DeallocateImpl(ptr);
+			};
+
+			return memory != nullptr;
+		}
+
+		template<typename... Args>
+		SharedPtr<T> AllocateShared(Args&&... params) {
+			T* ptr = static_cast<T*>(AllocateImpl());
+			if (ptr != nullptr) {
+				// Call the constructor on the newly allocated memory
+				new (ptr) T(std::forward<Args>(params)...);
+			}
+
+			return SharedPtr<T>(ptr, deleteFn);
+		}
+
+		template<typename... Args>
+		UniquePtr<T> AllocateUnique(Args&&... params) {
+			T* ptr = static_cast<T*>(AllocateImpl());
+			if (ptr != nullptr) {
+				// Call the constructor on the newly allocated memory
+				new (ptr) T(std::forward<Args>(params)...);
+			}
+
+			return UniquePtr<T>(ptr, deleteFn);
+		}
+
+		template<typename... Args>
+		T* AllocateRaw(Args&&... params) {
+			T* ptr = static_cast<T*>(AllocateImpl());
+			if (ptr != nullptr) {
+				// Call the constructor on the newly allocated memory
+				new (ptr) T(std::forward<Args>(params)...);
+			}
+
+			return ptr;
+		}
+
+		T* AllocateWithoutConstructor() {
+			return static_cast<T*>(AllocateImpl());
+		}
+
+		void Deallocate(size_t index) {
+			size_t chunkOffset = index * chunkSize;
+			void* ptr = reinterpret_cast<char*>(memory) + chunkOffset;
+			reinterpret_cast<T*>(ptr)->~T();
+			DeallocateImpl(ptr);
+		}
+
+		void Deallocate(void* ptr) {
+			reinterpret_cast<T*>(ptr)->~T();
+			DeallocateImpl(ptr);
+		}
+
+		void DeallocateWithoutDestructor(size_t index) {
+			size_t chunkOffset = index * chunkSize;
+			void* ptr = reinterpret_cast<char*>(memory) + chunkOffset;
+			DeallocateImpl(ptr);
+		}
+
+		void DeallocateWithoutDestructor(void* ptr) {
+			DeallocateImpl(ptr);
+		}
+	};
+}

--- a/sources/code/Common/Memory/Allocators/StackAllocator.cpp
+++ b/sources/code/Common/Memory/Allocators/StackAllocator.cpp
@@ -1,0 +1,3 @@
+#include "StackAllocator.hpp"
+
+using namespace Grindstone::Allocators;

--- a/sources/code/Common/Memory/Allocators/StackAllocator.hpp
+++ b/sources/code/Common/Memory/Allocators/StackAllocator.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace Grindstone::Allocators {
+	/**
+	 * \brief A stack allocator where memory can only be deallocated in order (LIFO).
+	 *
+	 * Memory in a stack allocator is allocated sequentially, and can only be deallocated
+	 * in reverse order (LIFO).
+	 * 
+	 */
+	class StackAllocator {
+	public:
+		bool Initialize(size_t size);
+		bool Allocate(size_t size);
+	};
+}

--- a/sources/code/Common/Memory/Memory.hpp
+++ b/sources/code/Common/Memory/Memory.hpp
@@ -1,0 +1,4 @@
+#pragma once
+
+#include "Allocators.hpp"
+#include "SmartPointers.hpp"

--- a/sources/code/Common/Memory/SmartPointers.hpp
+++ b/sources/code/Common/Memory/SmartPointers.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "SmartPointers/UniquePtr.hpp"
+#include "SmartPointers/SharedPtr.hpp"
+#include "SmartPointers/WeakPtr.hpp"

--- a/sources/code/Common/Memory/SmartPointers/SharedPtr.hpp
+++ b/sources/code/Common/Memory/SmartPointers/SharedPtr.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+struct SharedPtrRefCounter {
+	unsigned int refCount = 1;
+};
+
+template<typename T>
+class SharedPtr {
+public:
+
+	SharedPtr() = default;
+
+	SharedPtr(T* ptr) : ptr(ptr), refCounter(new SharedPtrRefCounter()) {}
+
+	SharedPtr(const SharedPtr& obj) : ptr(obj.ptr), refCounter(obj.refCounter) {
+		if (refCounter) {
+			++refCounter->refCount;	
+		}
+	}
+
+	SharedPtr& operator=(const SharedPtr& obj) {
+		if (ptr && refCounter) {
+			if (--refCounter->refCount == 0) {
+				delete ptr;
+				delete refCounter;
+			}
+		}
+
+		ptr = obj->ptr;
+		refCounter = obj->refCounter;
+
+		if (ptr && refCounter) {
+			++refCounter->refCount;
+		}
+	}
+
+	T* operator->() {
+		return this->ptr;
+	}
+
+	T& operator*() {
+		return *(this->ptr);
+	}
+
+	~SharedPtr() {
+		if (refCounter != nullptr && ptr != nullptr) {
+			if (--refCounter->refCount == 0) {
+				delete ptr;
+				delete refCounter;
+			}
+		}
+	}
+
+private:
+	T* ptr = nullptr;
+	SharedPtrRefCounter* refCounter = nullptr;
+};
+
+template<typename T, typename... Args>
+SharedPtr<T> MakeShared(Args&&... params) {
+	return new T(std::forward<Args>(params)...);
+}

--- a/sources/code/Common/Memory/SmartPointers/UniquePtr.hpp
+++ b/sources/code/Common/Memory/SmartPointers/UniquePtr.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+template<typename T>
+class UniquePtr {
+public:
+
+	UniquePtr() = default;
+
+	UniquePtr(T* ptr) : ptr(ptr) {}
+
+	template<typename... Args>
+	UniquePtr(Args&&... params) : ptr(new T(std::forward<Args>(params)...)) {}
+
+	UniquePtr(const UniquePtr& obj) = delete;
+	UniquePtr& operator=(const UniquePtr& obj) = delete;
+
+	T* operator->() {
+		return this->ptr;
+	}
+
+	T& operator*() {
+		return *(this->ptr);
+	}
+
+	~UniquePtr() {
+		if (ptr != nullptr) {
+			delete ptr;
+		}
+	}
+
+private:
+	T* ptr = nullptr;
+};
+
+template<typename T, typename... Args>
+UniquePtr<T> MakeUnique(Args&&... params) {
+	return new T(std::forward<Args>(params)...);
+}

--- a/sources/code/Common/Memory/SmartPointers/UniquePtr.hpp
+++ b/sources/code/Common/Memory/SmartPointers/UniquePtr.hpp
@@ -1,15 +1,14 @@
 #pragma once
 
+#include <functional>
+
 template<typename T>
 class UniquePtr {
 public:
 
 	UniquePtr() = default;
 
-	UniquePtr(T* ptr) : ptr(ptr) {}
-
-	template<typename... Args>
-	UniquePtr(Args&&... params) : ptr(new T(std::forward<Args>(params)...)) {}
+	UniquePtr(T* ptr, std::function<void(void*)> deleteFn) : ptr(ptr), deleteFn(deleteFn) {}
 
 	UniquePtr(const UniquePtr& obj) = delete;
 	UniquePtr& operator=(const UniquePtr& obj) = delete;
@@ -24,12 +23,19 @@ public:
 
 	~UniquePtr() {
 		if (ptr != nullptr) {
-			delete ptr;
+			ptr->~T();
+
+			if (deleteFn) {
+				deleteFn(ptr);
+			}
+
+			ptr = nullptr;
 		}
 	}
 
 private:
 	T* ptr = nullptr;
+	std::function<void(void*)> deleteFn;
 };
 
 template<typename T, typename... Args>

--- a/sources/code/Common/Memory/SmartPointers/WeakPtr.hpp
+++ b/sources/code/Common/Memory/SmartPointers/WeakPtr.hpp
@@ -1,0 +1,1 @@
+#pragma once

--- a/sources/code/Common/Memory/SmartPointers/WeakPtr.hpp
+++ b/sources/code/Common/Memory/SmartPointers/WeakPtr.hpp
@@ -1,1 +1,2 @@
 #pragma once
+

--- a/sources/code/Common/ResourcePipeline/Uuid.cpp
+++ b/sources/code/Common/ResourcePipeline/Uuid.cpp
@@ -6,14 +6,14 @@
 
 Grindstone::Uuid Grindstone::Uuid::CreateRandom() {
 	Uuid newUuid;
-	bool hasSuccessfullyCreatedRandomUuid = UuidCreate((UUID*)&(newUuid.uuid)) == RPC_S_OK;
+	bool hasSuccessfullyCreatedRandomUuid = UuidCreate((::UUID*)&(newUuid.uuid)) == RPC_S_OK;
 	GS_ASSERT_ENGINE_WITH_MESSAGE(hasSuccessfullyCreatedRandomUuid, "Could not create a random uuid.")
 
 	return newUuid;
 }
 
 Grindstone::Uuid::Uuid(const char* str) {
-	if (UuidFromString((unsigned char*)str, (UUID*)&uuid) != RPC_S_OK) {
+	if (UuidFromString((unsigned char*)str, (::UUID*)&uuid) != RPC_S_OK) {
 		GS_BREAK_WITH_MESSAGE("Could not create a random uuid.")
 		memset(uuid, 0, sizeof(uuid));
 	}
@@ -21,7 +21,7 @@ Grindstone::Uuid::Uuid(const char* str) {
 
 std::string Grindstone::Uuid::ToString() const {
 	unsigned char* uuidCstr;
-	if (UuidToString((UUID*)&uuid, &uuidCstr) == RPC_S_OK) {
+	if (UuidToString((::UUID*)&uuid, &uuidCstr) == RPC_S_OK) {
 		std::string uuidStr((char*)uuidCstr);
 		RpcStringFreeA(&uuidCstr);
 

--- a/sources/code/Common/String.hpp
+++ b/sources/code/Common/String.hpp
@@ -3,9 +3,7 @@
 #include <string>
 #include <string_view>
 
-#define GS_TEXT(x) L ## x
-
 namespace Grindstone {
-	using String = std::wstring;
-	using StringRef = std::wstring_view;
+	using String = std::string;
+	using StringRef = std::string_view;
 }

--- a/sources/code/Common/Utilities/ModuleLoading.cpp
+++ b/sources/code/Common/Utilities/ModuleLoading.cpp
@@ -23,13 +23,13 @@ Handle Modules::Load(std::string name) {
 }
 
 void Modules::Unload(Handle handle) {
+	if (handle) {
 #if defined(_WIN32)
-	if (handle)
 		FreeLibrary(handle);
 #elif defined(__linux__)
-	if (handle)
 		dlclose(handle);
 #endif
+	}
 }
 
 void* Modules::GetFunction(Handle module, const char *name) {

--- a/sources/code/Common/Utilities/ModuleLoading.hpp
+++ b/sources/code/Common/Utilities/ModuleLoading.hpp
@@ -8,19 +8,15 @@
 #include <dlfcn.h>
 #endif
 
-namespace Grindstone {
-	namespace Utilities {
-		namespace Modules {
+namespace Grindstone::Utilities::Modules {
 #if defined(_WIN32)
-			typedef HMODULE Handle;
+	using Handle = HMODULE;
 #elif defined(__linux__)
-			typedef void* Handle;
+	using Handle = void*;
 #endif
 
-			Grindstone::Utilities::Modules::Handle Load(std::string name);
-			void Unload(Grindstone::Utilities::Modules::Handle handle);
+	Grindstone::Utilities::Modules::Handle Load(std::string name);
+	void Unload(Grindstone::Utilities::Modules::Handle handle);
 
-			void* GetFunction(Grindstone::Utilities::Modules::Handle handle, const char *name);
-		}
-	}
+	void* GetFunction(Grindstone::Utilities::Modules::Handle handle, const char *name);
 }

--- a/sources/code/Editor/CMakeLists.txt
+++ b/sources/code/Editor/CMakeLists.txt
@@ -3,6 +3,8 @@ set(EDITOR_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 file(GLOB_RECURSE SOURCE_MAIN
 	Main.cpp ${CODE_DIR}/NatvisFile.natvis
 	${COMMON_DIR}/Utilities/ModuleLoading.cpp ${ENGINECORE_DIR}/Utils/Utilities.cpp
+	${COMMON_DIR}/Memory/Allocators/DynamicAllocator.cpp ${COMMON_DIR}/Memory/Allocators/DynamicAllocator.hpp
+	${ENGINECORE_DIR}/Utils/MemoryAllocator.cpp ${ENGINECORE_DIR}/Utils/MemoryAllocator.hpp
 	${COMMON_DIR}/ResourcePipeline/AssetType.cpp ${COMMON_DIR}/ResourcePipeline/AssetType.hpp
 	${COMMON_DIR}/ResourcePipeline/MetaFile.cpp ${COMMON_DIR}/ResourcePipeline/MetaFile.hpp
 	${COMMON_DIR}/ResourcePipeline/Uuid.cpp  ${COMMON_DIR}/ResourcePipeline/Uuid.hpp
@@ -53,10 +55,10 @@ file(GLOB_RECURSE HEADER_IMGUI_PREFS_PROJECT_EDITOR "${EDITOR_DIR}/ImguiEditor/P
 source_group("Imgui Editor\\Settings\\Project\\Source Files" FILES ${SOURCE_IMGUI_PREFS_PROJECT_EDITOR})
 source_group("Imgui Editor\\Settings\\Project\\Header Files" FILES ${HEADER_IMGUI_PREFS_PROJECT_EDITOR})
 
-file(GLOB_RECURSE SOURCE_IMGUI_COMPONENtS_EDITOR "${EDITOR_DIR}/ImguiEditor/Components/*.cpp")
-file(GLOB_RECURSE HEADER_IMGUI_COMPONENtS_EDITOR "${EDITOR_DIR}/ImguiEditor/Components/*.hpp")
-source_group("Imgui Editor\\Components\\Source Files" FILES ${SOURCE_IMGUI_COMPONENtS_EDITOR})
-source_group("Imgui Editor\\Components\\Header Files" FILES ${HEADER_IMGUI_COMPONENtS_EDITOR})
+file(GLOB_RECURSE SOURCE_IMGUI_COMPONENTS_EDITOR "${EDITOR_DIR}/ImguiEditor/Components/*.cpp")
+file(GLOB_RECURSE HEADER_IMGUI_COMPONENTS_EDITOR "${EDITOR_DIR}/ImguiEditor/Components/*.hpp")
+source_group("Imgui Editor\\Components\\Source Files" FILES ${SOURCE_IMGUI_COMPONENTS_EDITOR})
+source_group("Imgui Editor\\Components\\Header Files" FILES ${HEADER_IMGUI_COMPONENTS_EDITOR})
 
 file(GLOB_RECURSE SOURCE_IMGUI_EDITOR "${EDITOR_DIR}/ImguiEditor/*.cpp")
 file(GLOB_RECURSE HEADER_IMGUI_EDITOR "${EDITOR_DIR}/ImguiEditor/*.hpp")

--- a/sources/code/Editor/EditorCamera.cpp
+++ b/sources/code/Editor/EditorCamera.cpp
@@ -78,6 +78,11 @@ EditorCamera::EditorCamera() {
 	UpdateViewMatrix();
 }
 
+EditorCamera::~EditorCamera() {
+	delete renderer;
+	renderer = nullptr;
+}
+
 uint64_t EditorCamera::GetRenderOutput() {
 	return (uint64_t)(static_cast<GraphicsAPI::VulkanDescriptorSet*>(descriptorSet)->GetDescriptorSet());
 }

--- a/sources/code/Editor/EditorCamera.hpp
+++ b/sources/code/Editor/EditorCamera.hpp
@@ -21,6 +21,7 @@ namespace Grindstone {
 		class EditorCamera {
 		public:
 			EditorCamera();
+			~EditorCamera();
 			uint64_t GetRenderOutput();
 			void Render(GraphicsAPI::CommandBuffer* commandBuffer);
 			void RenderPlayModeCamera(GraphicsAPI::CommandBuffer* commandBuffer);

--- a/sources/code/Editor/ImguiEditor/StatsPanel.cpp
+++ b/sources/code/Editor/ImguiEditor/StatsPanel.cpp
@@ -132,11 +132,11 @@ namespace Grindstone::Editor::ImguiEditor {
 
 		{
 			const Memory::AllocatorCore& allocator = engineCore.GetAllocator();
-			const size_t oneMB = 1024u * 1024u;
-			const size_t memUsed = allocator.GetUsed() / oneMB;
-			const size_t memTotal = allocator.GetTotal() / oneMB;
+			const size_t oneKB = 1024u;
+			const size_t memUsed = allocator.GetUsed() / oneKB;
+			const size_t memTotal = allocator.GetTotal() / oneKB;
 			const float memUsedPct = memUsed * 100.0f / memTotal;
-			ImGui::Text("Memory Used: %zuMB / %zuMB", memUsed, memTotal);
+			ImGui::Text("Memory Used: %zuKB / %zuKB", memUsed, memTotal);
 			ImGui::ProgressBar(memUsedPct, ImVec2(maxWidth, 0));
 		}
 

--- a/sources/code/Editor/ImguiEditor/StatsPanel.cpp
+++ b/sources/code/Editor/ImguiEditor/StatsPanel.cpp
@@ -108,6 +108,8 @@ namespace Grindstone::Editor::ImguiEditor {
 	}
 
 	void StatsPanel::RenderContents() {
+		float maxWidth = ImGui::GetContentRegionAvail().x;
+
 		totalFrameCount++;
 		frameCountSinceLastRender++;
 
@@ -124,7 +126,22 @@ namespace Grindstone::Editor::ImguiEditor {
 		ImGui::Text("Frame Time (Seconds): %f", lastRenderedDeltaTime);
 		ImGui::Text("Frames Per Second: %f", 1 / lastRenderedDeltaTime);
 
+		ImGui::Separator();
+
 		EngineCore& engineCore = Editor::Manager::GetEngineCore();
+
+		{
+			const Memory::AllocatorCore& allocator = engineCore.GetAllocator();
+			const size_t oneMB = 1024u * 1024u;
+			const size_t memUsed = allocator.GetUsed() / oneMB;
+			const size_t memTotal = allocator.GetTotal() / oneMB;
+			const float memUsedPct = memUsed * 100.0f / memTotal;
+			ImGui::Text("Memory Used: %zuMB / %zuMB", memUsed, memTotal);
+			ImGui::ProgressBar(memUsedPct, ImVec2(maxWidth, 0));
+		}
+
+		ImGui::Separator();
+
 		Assets::AssetManager* assetManager = engineCore.assetManager;
 
 		RenderRenderQueuesTable(engineCore);

--- a/sources/code/Editor/ImguiEditor/ViewportPanel.cpp
+++ b/sources/code/Editor/ImguiEditor/ViewportPanel.cpp
@@ -36,6 +36,11 @@ ViewportPanel::ViewportPanel() {
 	dispatcher->AddEventListener(Grindstone::Events::EventType::MouseMoved, std::bind(&ViewportPanel::OnMouseMovedEvent, this, std::placeholders::_1));
 }
 
+ViewportPanel::~ViewportPanel() {
+	delete camera;
+	camera = nullptr;
+}
+
 bool ViewportPanel::OnMouseButtonEvent(Grindstone::Events::BaseEvent* baseEvent) {
 	Grindstone::Events::MousePressEvent* ev = static_cast<Grindstone::Events::MousePressEvent*>(baseEvent);
 

--- a/sources/code/Editor/ImguiEditor/ViewportPanel.hpp
+++ b/sources/code/Editor/ImguiEditor/ViewportPanel.hpp
@@ -15,6 +15,7 @@ namespace Grindstone {
 			class ViewportPanel {
 			public:
 				ViewportPanel();
+				~ViewportPanel();
 				void Render();
 				void RenderCamera(GraphicsAPI::CommandBuffer* commandBuffer);
 				EditorCamera* GetCamera() const;

--- a/sources/code/EngineCore/Assets/AssetManager.cpp
+++ b/sources/code/EngineCore/Assets/AssetManager.cpp
@@ -14,25 +14,28 @@ using namespace Grindstone;
 using namespace Grindstone::Assets;
 
 AssetManager::AssetManager(AssetLoader* assetLoader) {
+	Memory::AllocatorCore& allocator = EngineCore::GetInstance().GetAllocator();
+
 	// TODO: Decide via preprocessor after we implement building the engine code during game build
 	this->assetLoader = assetLoader == nullptr
-		? static_cast<AssetLoader*>(new ArchiveAssetLoader())
+		? static_cast<AssetLoader*>(allocator.Allocate<ArchiveAssetLoader>())
 		: assetLoader;
 
 	size_t count = static_cast<size_t>(AssetType::Count);
 	assetTypeNames.resize(count);
 	assetTypeImporters.resize(count);
 	RegisterAssetType(AssetType::Undefined, "Undefined", nullptr);
-	RegisterAssetType(ShaderAsset::GetStaticType(), "ShaderAsset", new ShaderImporter());
-	RegisterAssetType(TextureAsset::GetStaticType(), "TextureAsset", new TextureImporter());
-	RegisterAssetType(MaterialAsset::GetStaticType(), "MaterialAsset", new MaterialImporter());
+	RegisterAssetType(ShaderAsset::GetStaticType(), "ShaderAsset", allocator.Allocate<ShaderImporter>());
+	RegisterAssetType(TextureAsset::GetStaticType(), "TextureAsset", allocator.Allocate<TextureImporter>());
+	RegisterAssetType(MaterialAsset::GetStaticType(), "MaterialAsset", allocator.Allocate<MaterialImporter>());
 }
 
 AssetManager::~AssetManager() {
-	delete assetLoader;
+	Memory::AllocatorCore& allocator = EngineCore::GetInstance().GetAllocator();
+	allocator.Free(assetLoader);
 
 	for (AssetImporter*& importer : assetTypeImporters) {
-		delete importer;
+		allocator.Free(importer);
 		importer = nullptr;
 	}
 }

--- a/sources/code/EngineCore/Assets/AssetManager.hpp
+++ b/sources/code/EngineCore/Assets/AssetManager.hpp
@@ -71,6 +71,7 @@ namespace Grindstone::Assets {
 		// if there is a new type, we can change all assetTypes in meta files.
 		virtual void RegisterAssetType(AssetType assetType, const char* typeName, AssetImporter* importer);
 	private:
+		bool ownsAssetLoader = false;
 		Grindstone::Assets::AssetLoader* assetLoader = nullptr;
 		std::vector<std::string> assetTypeNames;
 		std::vector<AssetImporter*> assetTypeImporters;

--- a/sources/code/EngineCore/CMakeLists.txt
+++ b/sources/code/EngineCore/CMakeLists.txt
@@ -68,6 +68,11 @@ file(GLOB_RECURSE HEADER_EVENTS "${ENGINE_CORE_DIR}/Events/*.hpp")
 source_group("Events\\Source Files" FILES ${SOURCE_EVENTS})
 source_group("Events\\Header Files" FILES ${HEADER_EVENTS})
 
+file(GLOB_RECURSE SOURCE_MEMORY ${ENGINE_CORE_DIR}/Utils/MemoryAllocator.cpp ${COMMON_DIR}/Memory/Allocators/DynamicAllocator.cpp ${COMMON_DIR}/Memory/Allocators/LinearAllocator.cpp ${COMMON_DIR}/Memory/Allocators/StackAllocator.cpp)
+file(GLOB_RECURSE HEADER_MEMORY ${ENGINE_CORE_DIR}/Utils/MemoryAllocator.hpp ${COMMON_DIR}/Memory/Allocators/DynamicAllocator.hpp ${COMMON_DIR}/Memory/Allocators/LinearAllocator.hpp ${COMMON_DIR}/Memory/Allocators/StackAllocator.hpp ${ENGINE_CORE_DIR}/Memory/Allocators.hpp ${ENGINE_CORE_DIR}/Memory/Memory.hpp)
+source_group("Memory\\Source Files" FILES ${SOURCE_MEMORY})
+source_group("Memory\\Header Files" FILES ${HEADER_MEMORY})
+
 file(GLOB_RECURSE SOURCE_COMMON_UTILS ${COMMON_DIR}/Utilities/ModuleLoading.cpp ${ENGINE_CORE_DIR}/Utils/Utilities.cpp ${COMMON_DIR}/ResourcePipeline/Uuid.cpp ${COMMON_DIR}/Graphics/Formats.cpp ${ENGINE_CORE_DIR}/Utils/WindowGlue.cpp)
 file(GLOB_RECURSE HEADER_COMMON_UTILS ${COMMON_DIR}/Utilities/ModuleLoading.hpp ${ENGINE_CORE_DIR}/Utils/Utilities.hpp ${COMMON_DIR}/ResourcePipeline/Uuid.hpp ${COMMON_DIR}/Buffer.hpp)
 source_group("Utilities\\Source Files" FILES ${SOURCE_COMMON_UTILS})
@@ -104,6 +109,7 @@ set(ENGINE_CORE_SOURCES
 	${SOURCE_REFLECTION}
 	${SOURCE_RENDERING}
 	${SOURCE_EVENTS}
+	${SOURCE_MEMORY}
 )
 
 set(ENGINE_CORE_HEADERS
@@ -128,6 +134,7 @@ set(ENGINE_CORE_HEADERS
 	${HEADER_REFLECTION}
 	${HEADER_RENDERING}
 	${HEADER_EVENTS}
+	${HEADER_MEMORY}
 )
 
 add_library(EngineCore MODULE ${ENGINE_CORE_SOURCES} ${ENGINE_CORE_HEADERS})

--- a/sources/code/EngineCore/EngineCore.cpp
+++ b/sources/code/EngineCore/EngineCore.cpp
@@ -31,7 +31,7 @@ bool EngineCore::Initialize(CreateInfo& createInfo) {
 	engineAssetsPath = engineBinaryPath.parent_path() / "engineassets";
 
 	const size_t megabytesInGig = 1024u;
-	if (!memoryAllocator.Initialize(megabytesInGig * 2u)) {
+	if (!memoryAllocator.Initialize(megabytesInGig * 1u)) {
 		return false;
 	}
 

--- a/sources/code/EngineCore/EngineCore.cpp
+++ b/sources/code/EngineCore/EngineCore.cpp
@@ -161,7 +161,7 @@ void EngineCore::UpdateWindows() {
 
 EngineCore::~EngineCore() {
 	Logger::Print("Closing...");
-	sizeof(Grindstone::AssetRendererManager);
+
 	memoryAllocator.Free(sceneManager);
 	memoryAllocator.Free(assetRendererManager);
 	memoryAllocator.Free(assetManager);
@@ -174,6 +174,8 @@ EngineCore::~EngineCore() {
 	if (!memoryAllocator.IsEmpty()) {
 		Logger::Print(LogSeverity::Error, "Uncleared memory: {0} bytes left!", memoryAllocator.GetUsed());
 	}
+
+	Logger::Print("Closed.");
 }
 
 void EngineCore::RegisterGraphicsCore(GraphicsAPI::Core* newGraphicsCore) {

--- a/sources/code/EngineCore/EngineCore.cpp
+++ b/sources/code/EngineCore/EngineCore.cpp
@@ -171,7 +171,7 @@ EngineCore::~EngineCore() {
 	memoryAllocator.Free(systemRegistrar);
 	memoryAllocator.Free(eventDispatcher);
 
-	if (!memoryAllocator.IsCleared()) {
+	if (!memoryAllocator.IsEmpty()) {
 		Logger::Print(LogSeverity::Error, "Uncleared memory: {0} bytes left!", memoryAllocator.GetUsed());
 	}
 }
@@ -213,7 +213,7 @@ Events::Dispatcher* EngineCore::GetEventDispatcher() const {
 }
 
 BaseRenderer* EngineCore::CreateRenderer(GraphicsAPI::RenderPass* targetRenderPass) {
-	return memoryAllocator.Allocate<DeferredRenderer>(targetRenderPass);
+	return new DeferredRenderer(targetRenderPass);
 }
 
 std::filesystem::path EngineCore::GetProjectPath() const {

--- a/sources/code/EngineCore/EngineCore.hpp
+++ b/sources/code/EngineCore/EngineCore.hpp
@@ -5,27 +5,28 @@
 #include <functional>
 #include <chrono>
 
-#include "Common/Logging.hpp"
+#include <Common/Logging.hpp>
+#include <EngineCore/Utils/MemoryAllocator.hpp>
 
 namespace Grindstone {
 	namespace GraphicsAPI {
 		class Core;
 		class RenderPass;
-	};
+	}
 
 	namespace Input {
 		class Interface;
-	};
+	}
 
 	namespace Plugins {
 		class Manager;
 		class BaseEditorInterface;
-	};
+	}
 
 	namespace ECS {
 		class ComponentRegistrar;
 		class SystemRegistrar;
-	};
+	}
 
 	namespace SceneManagement {
 		class SceneManager;
@@ -101,6 +102,7 @@ namespace Grindstone {
 		virtual void CalculateDeltaTime();
 		virtual double GetTimeSinceLaunch() const;
 		virtual double GetDeltaTime() const;
+		virtual Memory::AllocatorCore& GetAllocator();
 	public:
 		DisplayManager* displayManager = nullptr;
 		WindowManager* windowManager = nullptr;
@@ -113,6 +115,7 @@ namespace Grindstone {
 		double deltaTime = 0.0;
 		std::chrono::steady_clock::time_point firstFrameTime;
 		std::chrono::steady_clock::time_point lastFrameTime;
+		Memory::AllocatorCore memoryAllocator;
 		SceneManagement::SceneManager* sceneManager = nullptr;
 		ECS::ComponentRegistrar* componentRegistrar = nullptr;
 		ECS::SystemRegistrar* systemRegistrar = nullptr;

--- a/sources/code/EngineCore/Utils/MemoryAllocator.cpp
+++ b/sources/code/EngineCore/Utils/MemoryAllocator.cpp
@@ -29,7 +29,7 @@ void* AllocatorCore::Allocate(size_t size) {
 	return allocator.Allocate(size);
 }
 
-bool AllocatorCore::Free(void* memPtr) {
+bool AllocatorCore::FreeWithoutDestructor(void* memPtr) {
 	return allocator.Free(memPtr);
 }
 
@@ -41,6 +41,6 @@ size_t Grindstone::Memory::AllocatorCore::GetTotal() const {
 	return allocator.GetTotalMemorySize();
 }
 
-bool Grindstone::Memory::AllocatorCore::IsCleared() const {
-	return allocator.GetUsedSize() == 0u;
+bool Grindstone::Memory::AllocatorCore::IsEmpty() const {
+	return allocator.IsEmpty();
 }

--- a/sources/code/EngineCore/Utils/MemoryAllocator.cpp
+++ b/sources/code/EngineCore/Utils/MemoryAllocator.cpp
@@ -1,0 +1,46 @@
+#include <cstring>
+
+#include <Common/String.hpp>
+
+#include "MemoryAllocator.hpp"
+
+using namespace Grindstone::Memory;
+
+bool AllocatorCore::Initialize(size_t sizeInMegs) {
+	return allocator.Initialize(sizeInMegs * 1024u * 1024u);
+}
+
+Grindstone::StringRef AllocatorCore::AllocateString(size_t size) {
+	char* memory = static_cast<char*>(Allocate(size));
+
+	return Grindstone::StringRef(memory, size);
+}
+
+Grindstone::StringRef AllocatorCore::AllocateString(Grindstone::StringRef srcString) {
+	size_t srcStringLength = srcString.size() + 1;
+
+	char* memory = static_cast<char*>(Allocate(srcStringLength));
+	memcpy(memory, srcString.data(), srcStringLength);
+
+	return Grindstone::StringRef(memory, srcStringLength - 1);
+}
+
+void* AllocatorCore::Allocate(size_t size) {
+	return allocator.Allocate(size);
+}
+
+bool AllocatorCore::Free(void* memPtr) {
+	return allocator.Free(memPtr);
+}
+
+size_t Grindstone::Memory::AllocatorCore::GetUsed() const {
+	return allocator.GetUsedSize();
+}
+
+size_t Grindstone::Memory::AllocatorCore::GetTotal() const {
+	return allocator.GetTotalMemorySize();
+}
+
+bool Grindstone::Memory::AllocatorCore::IsCleared() const {
+	return allocator.GetUsedSize() == 0u;
+}

--- a/sources/code/EngineCore/Utils/MemoryAllocator.cpp
+++ b/sources/code/EngineCore/Utils/MemoryAllocator.cpp
@@ -11,7 +11,7 @@ bool AllocatorCore::Initialize(size_t sizeInMegs) {
 }
 
 Grindstone::StringRef AllocatorCore::AllocateString(size_t size) {
-	char* memory = static_cast<char*>(Allocate(size));
+	char* memory = static_cast<char*>(allocator.AllocateRaw(size));
 
 	return Grindstone::StringRef(memory, size);
 }
@@ -19,14 +19,10 @@ Grindstone::StringRef AllocatorCore::AllocateString(size_t size) {
 Grindstone::StringRef AllocatorCore::AllocateString(Grindstone::StringRef srcString) {
 	size_t srcStringLength = srcString.size() + 1;
 
-	char* memory = static_cast<char*>(Allocate(srcStringLength));
+	char* memory = static_cast<char*>(allocator.AllocateRaw(srcStringLength));
 	memcpy(memory, srcString.data(), srcStringLength);
 
 	return Grindstone::StringRef(memory, srcStringLength - 1);
-}
-
-void* AllocatorCore::Allocate(size_t size) {
-	return allocator.Allocate(size);
 }
 
 bool AllocatorCore::FreeWithoutDestructor(void* memPtr) {

--- a/sources/code/EngineCore/Utils/MemoryAllocator.hpp
+++ b/sources/code/EngineCore/Utils/MemoryAllocator.hpp
@@ -11,12 +11,12 @@ namespace Grindstone::Memory {
 		StringRef AllocateString(Grindstone::StringRef srcString);
 
 		void* Allocate(size_t size);
-		bool Free(void* memPtr);
+		bool FreeWithoutDestructor(void* memPtr);
 
 		virtual size_t GetUsed() const;
 		virtual size_t GetTotal() const;
 
-		virtual bool IsCleared() const;
+		virtual bool IsEmpty() const;
 
 		template<typename T, typename... Args>
 		T* Allocate(Args&&... params) {
@@ -32,6 +32,17 @@ namespace Grindstone::Memory {
 		template<typename T>
 		T* AllocateWithoutConstructor() {
 			return static_cast<T*>(allocator.Allocate(sizeof(T)));
+		}
+
+		template<typename T>
+		bool Free(T* memPtr, bool shouldClear = false) {
+			bool retVal = allocator.Free(memPtr, shouldClear);
+			if (retVal) {
+				reinterpret_cast<T*>(memPtr)->~T();
+				return true;
+			}
+
+			return false;
 		}
 
 	private:

--- a/sources/code/EngineCore/Utils/MemoryAllocator.hpp
+++ b/sources/code/EngineCore/Utils/MemoryAllocator.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <Common/Memory/Allocators/DynamicAllocator.hpp>
+#include <Common/String.hpp>
+
+namespace Grindstone::Memory {
+	class AllocatorCore {
+	public:
+		bool Initialize(size_t sizeInMegs);
+		StringRef AllocateString(size_t size);
+		StringRef AllocateString(Grindstone::StringRef srcString);
+
+		void* Allocate(size_t size);
+		bool Free(void* memPtr);
+
+		virtual size_t GetUsed() const;
+		virtual size_t GetTotal() const;
+
+		virtual bool IsCleared() const;
+
+		template<typename T, typename... Args>
+		T* Allocate(Args&&... params) {
+			T* ptr = static_cast<T*>(allocator.Allocate(sizeof(T)));
+			if (ptr != nullptr) {
+				// Call the constructor on the newly allocated memory
+				new (ptr) T(std::forward<Args>(params)...);
+			}
+
+			return ptr;
+		}
+
+		template<typename T>
+		T* AllocateWithoutConstructor() {
+			return static_cast<T*>(allocator.Allocate(sizeof(T)));
+		}
+
+	private:
+		Allocators::DynamicAllocator allocator;
+	};
+}

--- a/sources/code/EngineCore/Utils/MemoryAllocator.hpp
+++ b/sources/code/EngineCore/Utils/MemoryAllocator.hpp
@@ -10,7 +10,6 @@ namespace Grindstone::Memory {
 		StringRef AllocateString(size_t size);
 		StringRef AllocateString(Grindstone::StringRef srcString);
 
-		void* Allocate(size_t size);
 		bool FreeWithoutDestructor(void* memPtr);
 
 		virtual size_t GetUsed() const;
@@ -19,19 +18,24 @@ namespace Grindstone::Memory {
 		virtual bool IsEmpty() const;
 
 		template<typename T, typename... Args>
+		UniquePtr<T> AllocateUnique(Args&&... params) {
+			return static_cast<T*>(allocator.AllocateUnique<T>(params));
+		}
+
+		template<typename T, typename... Args>
+		SharedPtr<T> AllocateShared(Args&&... params) {
+			return static_cast<T*>(allocator.AllocateShared<T>(params));
+		}
+
+		template<typename T, typename... Args>
 		T* Allocate(Args&&... params) {
-			T* ptr = static_cast<T*>(allocator.Allocate(sizeof(T)));
+			T* ptr = static_cast<T*>(allocator.AllocateRaw(sizeof(T)));
 			if (ptr != nullptr) {
 				// Call the constructor on the newly allocated memory
 				new (ptr) T(std::forward<Args>(params)...);
 			}
 
 			return ptr;
-		}
-
-		template<typename T>
-		T* AllocateWithoutConstructor() {
-			return static_cast<T*>(allocator.Allocate(sizeof(T)));
 		}
 
 		template<typename T>


### PR DESCRIPTION
Add memory allocators and smart pointers to the engine. Allocate just the core systems in EngineCore. Expose it to Editor, and show stats in the Editor Stats Panel.