### PR TITLE
DeferredRenderer / Post-Process Fixes

### DIFF
--- a/engineassets/pipelinesets/deferredPipeline/imageBasedLighting.gpset
+++ b/engineassets/pipelinesets/deferredPipeline/imageBasedLighting.gpset
@@ -101,7 +101,8 @@ pipelineSet "Image Based Lighting" inherits "DeferredLighting" {
 
 					static const float MAX_REFLECTION_LOD = 4.0;
 					float3 f0 = 0.32 * specularInput * specularInput;
-					float3 f90 = max(float3(1.0f - roughness), f0);
+					float oneMinusR = 1.0f - roughness;
+					float3 f90 = max(float3(oneMinusR, oneMinusR, oneMinusR), f0);
 					float3 F = Light_F(f0, f90, NV);
 					float3 prefilteredColor = specularMap.SampleLevel(gbufferSampler, reflectRay, roughness * MAX_REFLECTION_LOD).rgb;
 					float2 envBRDF  = brdfLUT.Sample(gbufferSampler, float2(NV, roughness)).rg;

--- a/engineassets/pipelinesets/deferredPipeline/imageBasedLighting.gpset
+++ b/engineassets/pipelinesets/deferredPipeline/imageBasedLighting.gpset
@@ -19,8 +19,8 @@ pipelineSet "Image Based Lighting" inherits "DeferredLighting" {
 				Texture2D<float4> brdfLUT : register(t1, space2);
 				TextureCube<float4> specularMap : register(t2, space2);
 
-				float3 Light_F(in float3 f0, in float f90, in float VH) {
-					return f0 + (f90-f0) * pow(1-VH, 5.0f);
+				float3 Light_F(in float3 f0, in float3 f90, in float VH) {
+					return f0 + (f90 - f0) * pow(clamp(1 - VH, 0.0f, 1.0f), 5.0f);
 				}
 
 				float3 FresnelSchlickRoughness(float cosTheta, float3 F0, float roughness) {
@@ -101,7 +101,7 @@ pipelineSet "Image Based Lighting" inherits "DeferredLighting" {
 
 					static const float MAX_REFLECTION_LOD = 4.0;
 					float3 f0 = 0.32 * specularInput * specularInput;
-					float f90 = clamp(50 * dot(f0, float3(0.33, 0.33, 0.33)), 0, 1);
+					float3 f90 = max(float3(1.0f - roughness), f0);
 					float3 F = Light_F(f0, f90, NV);
 					float3 prefilteredColor = specularMap.SampleLevel(gbufferSampler, reflectRay, roughness * MAX_REFLECTION_LOD).rgb;
 					float2 envBRDF  = brdfLUT.Sample(gbufferSampler, float2(NV, roughness)).rg;

--- a/engineassets/pipelinesets/deferredPipeline/imageBasedLighting.gpset
+++ b/engineassets/pipelinesets/deferredPipeline/imageBasedLighting.gpset
@@ -87,7 +87,7 @@ pipelineSet "Image Based Lighting" inherits "DeferredLighting" {
 
 					float depthFromTexture = gbufferDepth.Sample(gbufferSampler, input.scaledFragmentTexCoord).r;
 
-					float3 position = ComputeWorldSpacePosition(rendererUbo.projectionMatrix, rendererUbo.viewMatrix, input.fragmentTexCoord, depthFromTexture);
+					float3 position = ComputeWorldSpacePosition(rendererUbo.inverseProjectionMatrix, rendererUbo.inverseViewMatrix, input.fragmentTexCoord, depthFromTexture);
 					float3 albedo = gbufferAlbedo.Sample(gbufferSampler, input.scaledFragmentTexCoord).rgb;
 					float3 normal = gbufferNormals.Sample(gbufferSampler, input.scaledFragmentTexCoord).rgb;
 					float3 specularInput = gbufferSpecularRoughnessValue.rgb;
@@ -95,7 +95,7 @@ pipelineSet "Image Based Lighting" inherits "DeferredLighting" {
 					float ao = ssao.Sample(gbufferSampler, input.scaledFragmentTexCoord).r;
 
 					float3 eyeDir = normalize(rendererUbo.eyePos.xyz - position);
-					float3 reflectRay = 2 * dot(eyeDir, normal) * normal - eyeDir;
+					float3 reflectRay = reflect(-eyeDir, normal);
 
 					float NV = max(dot(normal, eyeDir), 0.0);
 

--- a/engineassets/pipelinesets/postProcessing/screenSpaceAmbientOcclusion.gpset
+++ b/engineassets/pipelinesets/postProcessing/screenSpaceAmbientOcclusion.gpset
@@ -32,7 +32,7 @@ pipelineSet "Screen-Space Ambient Occlusion" inherits "PostProcessing" {
 				static const int kernelSize = 64;
 
 				SamplerState gbufferSampler : register(s0, space1);
-				Texture2D<float4> depthTexture : register(t1, space1);
+				Texture2D<float> depthTexture : register(t1, space1);
 				Texture2D<float4> gbufferNormals : register(t2, space1);
 
 				struct SSAOBufferObject {
@@ -46,7 +46,8 @@ pipelineSet "Screen-Space Ambient Occlusion" inherits "PostProcessing" {
 				ConstantBuffer<SSAOBufferObject> ssaoUbo : register(b2, space2);
 
 				float mainFragment(VertexToFragment input) : SV_TARGET0 {
-					int2 noiseScale = int2(rendererUbo.renderResolution.x, rendererUbo.renderResolution.y) / 4;
+					float2 roundedResolution = floor(rendererUbo.renderResolution / 4.0f) * 4.0f;
+					float2 noiseScale = ceil(roundedResolution / 4.0f);
 
 					float depthFromTexture = depthTexture.Sample(gbufferSampler, input.scaledFragmentTexCoord).x;
 					float3 position = ComputeViewSpacePosition(rendererUbo.inverseProjectionMatrix, input.fragmentTexCoord, depthFromTexture).rgb;
@@ -70,7 +71,7 @@ pipelineSet "Screen-Space Ambient Occlusion" inherits "PostProcessing" {
 						float4 offset = float4(sampleKernel, 1.0);
 						offset      = mul(rendererUbo.projectionMatrix, offset);// from view to clip-space
 						offset.xyz /= offset.w;									// perspective divide
-						offset.xyz  = offset.xyz * 0.5 + float3(0.5, 0.5, 0.5);	// transform to range 0.0 - 1.0
+						offset.xyz  = float3(offset.x * 0.5 + 0.5, offset.y * 0.5 + 0.5, offset.z * 0.5 + 0.5);	// transform to range 0.0 - 1.0
 
 						float sampleDepth = depthTexture.Sample(gbufferSampler, offset.xy * rendererUbo.renderScale).x;
 						float sampleDepthLinear = ComputeViewSpacePosition(rendererUbo.inverseProjectionMatrix, offset.xy, sampleDepth).z;

--- a/engineassets/pipelinesets/postProcessing/screenSpaceAmbientOcclusionBlur.gpset
+++ b/engineassets/pipelinesets/postProcessing/screenSpaceAmbientOcclusionBlur.gpset
@@ -1,0 +1,51 @@
+include "$ENGINE/pipelinesets/common/matrixTransformations.gpset"
+include "$ENGINE/pipelinesets/common/postProcessingTemplate.gpset"
+
+pipelineSet "Ambient Occlusion Blur" inherits "PostProcessing" {
+	configuration "main" {
+		pass "main" {
+			shaderEntrypoint: vertex mainVertex
+			shaderEntrypoint: fragment mainFragment
+			renderQueue: "Ssao"
+
+			properties {
+				cull: back
+				depthBias: false
+				depthWrite: false
+				depthTest: false
+				depthClamp: false
+				depthCompareOp: lessOrEqual
+				attachments: {
+					colorMask: rgba
+					blendPreset: opaque
+				}
+			}
+
+			requiresBlocks [
+				GsInvertMatrix,
+				GsViewNormal,
+				GsComputeClipSpacePosition,
+				GsComputeViewSpacePosition
+			]
+
+			shaderHlsl {
+				SamplerState aoSampler : register(s0, space1);
+				Texture2D<float> aoImage : register(t1, space1);
+
+				float mainFragment(VertexToFragment input) : SV_TARGET0 {
+					float2 texelSize = float2(1 / rendererUbo.renderResolution.x, 1 / rendererUbo.renderResolution.y);
+
+					float result = 0.0;
+					for (int x = -2; x < 2; ++x)  {
+						for (int y = -2; y < 2; ++y)  {
+							float2 offset = float2(float(x), float(y)) * texelSize;
+							result += aoImage.Sample(aoSampler, input.scaledFragmentTexCoord + offset).r;
+						}
+					}
+					
+					return result / (4.0f * 4.0f);
+				}
+			}
+		}
+	}
+}

--- a/engineassets/pipelinesets/postProcessing/screenSpaceAmbientOcclusionBlur.gpset.meta
+++ b/engineassets/pipelinesets/postProcessing/screenSpaceAmbientOcclusionBlur.gpset.meta
@@ -1,0 +1,14 @@
+{
+    "assetImporterVersion": 0,
+    "metaFileVersion": 1,
+    "defaultUuid": "36d307d2-2758-4e2f-bd8a-de96616be011",
+    "subassets": [
+        {
+            "displayName": "Ambient Occlusion Blur",
+            "address": "@CORESHADERS/postProcessing/screenSpaceAmbientOcclusionBlur",
+            "subassetIdentifier": "Ambient Occlusion Blur",
+            "uuid": "36d307d2-2758-4e2f-bd8a-de96616be011",
+            "type": "GraphicsPipelineSet"
+        }
+    ]
+}

--- a/engineassets/pipelinesets/postProcessing/tonemap.gpset
+++ b/engineassets/pipelinesets/postProcessing/tonemap.gpset
@@ -40,14 +40,6 @@ pipelineSet "Tonemapping" inherits "PostProcessing" {
 
 				ConstantBuffer<PostProcessUbo> postProcessingUbo : register(b3, space2);
 
-				float3 linearToSRGB(float3 inColor) {
-					float3 outColor;
-					outColor.r = inColor.r <= 0.0031308 ? 12.92 * inColor.r : 1.055 * pow(inColor.r, 1.0/2.4) - 0.055;
-					outColor.g = inColor.g <= 0.0031308 ? 12.92 * inColor.g : 1.055 * pow(inColor.g, 1.0/2.4) - 0.055;
-					outColor.b = inColor.b <= 0.0031308 ? 12.92 * inColor.b : 1.055 * pow(inColor.b, 1.0/2.4) - 0.055;
-					return outColor;
-				}
-
 				float3 hdrTransform(float3 color) {
 					float a = 2.51f;
 					float b = 0.03f;
@@ -142,7 +134,6 @@ pipelineSet "Tonemapping" inherits "PostProcessing" {
 					combinedColor = applyVignette(sceneColor, inData.fragmentTexCoord);
 					combinedColor = applyGrain(sceneColor, resolution, inData.fragmentTexCoord);
 					combinedColor = hdrTransform(combinedColor);
-					combinedColor = linearToSRGB(combinedColor);
 
 					return float4(combinedColor, 1);
 				}

--- a/sources/code/Common/Graphics/Formats.hpp
+++ b/sources/code/Common/Graphics/Formats.hpp
@@ -26,6 +26,13 @@ namespace Grindstone::GraphicsAPI {
 		All = 7
 	};
 
+	enum class ImageDimension {
+		Invalid,
+		Dimension1D,
+		Dimension2D,
+		Dimension3D
+	};
+
 	enum class Format {
 		Invalid,
 		R4G4_UNORM_PACK8,

--- a/sources/code/Common/Graphics/Image.hpp
+++ b/sources/code/Common/Graphics/Image.hpp
@@ -55,7 +55,8 @@ namespace Grindstone::GraphicsAPI {
 			uint32_t mipLevels = 1;
 			uint32_t arrayLayers = 1;
 
-			Format format;
+			GraphicsAPI::Format format = GraphicsAPI::Format::Invalid;
+			GraphicsAPI::ImageDimension imageDimensions = GraphicsAPI::ImageDimension::Dimension2D;
 			Grindstone::Containers::BitsetFlags<ImageUsageFlags> imageUsage;
 
 			const char* initialData = nullptr;

--- a/sources/code/Plugins/EditorTextureImporter/TextureImporter.cpp
+++ b/sources/code/Plugins/EditorTextureImporter/TextureImporter.cpp
@@ -268,7 +268,7 @@ void TextureImporter::OutputDds(uint8_t* outData, uint64_t contentSize) {
 	outHeader.dwFlags = DDSD_REQUIRED | DDSD_MIPMAPCOUNT;
 	outHeader.dwHeight = texHeight;
 	outHeader.dwWidth = texWidth;
-	outHeader.dwDepth = 0;	
+	outHeader.dwDepth = 1;
 	outHeader.dwCaps = DDSCAPS_COMPLEX | DDSCAPS_TEXTURE;
 	outHeader.dwMipMapCount = 1;
 

--- a/sources/code/Plugins/GraphicsVulkan/VulkanImage.cpp
+++ b/sources/code/Plugins/GraphicsVulkan/VulkanImage.cpp
@@ -17,6 +17,7 @@ Vulkan::Image::Image(VkImage image, VkFormat format, uint32_t swapchainIndex) :
 	depth(1),
 	mipLevels(1),
 	arrayLayers(1),
+	imageDimension(ImageDimension::Dimension2D),
 	imageViewType(VkImageViewType::VK_IMAGE_VIEW_TYPE_2D),
 	aspect(VK_IMAGE_ASPECT_COLOR_BIT)
 {
@@ -32,6 +33,7 @@ Vulkan::Image::Image(const CreateInfo& createInfo) :
 	width(createInfo.width),
 	height(createInfo.height),
 	depth(createInfo.depth),
+	imageDimension(createInfo.imageDimensions),
 	mipLevels(createInfo.mipLevels),
 	arrayLayers(createInfo.arrayLayers),
 	format(createInfo.format),
@@ -100,23 +102,30 @@ void Vulkan::Image::Create() {
 			imageViewType = VkImageViewType::VK_IMAGE_VIEW_TYPE_CUBE;
 		}
 	}
-	else if (arrayLayers > 1) {
-		if (axisCount == 1) {
-			imageViewType = VkImageViewType::VK_IMAGE_VIEW_TYPE_1D_ARRAY;
-		}
-		else if (axisCount == 2) {
-			imageViewType = VkImageViewType::VK_IMAGE_VIEW_TYPE_2D_ARRAY;
-		}
-	}
 	else {
-		if (axisCount == 1) {
-			imageViewType = VkImageViewType::VK_IMAGE_VIEW_TYPE_1D;
-		}
-		else if (axisCount == 2) {
-			imageViewType = VkImageViewType::VK_IMAGE_VIEW_TYPE_2D;
-		}
-		else if (axisCount == 3) {
+		switch (imageDimension) {
+		case GraphicsAPI::ImageDimension::Dimension1D:
+			if (arrayLayers > 1) {
+				imageViewType = VkImageViewType::VK_IMAGE_VIEW_TYPE_1D_ARRAY;
+			}
+			else {
+				imageViewType = VkImageViewType::VK_IMAGE_VIEW_TYPE_1D;
+			}
+			break;
+		case GraphicsAPI::ImageDimension::Dimension2D:
+			if (arrayLayers > 1) {
+				imageViewType = VkImageViewType::VK_IMAGE_VIEW_TYPE_2D_ARRAY;
+			}
+			else {
+				imageViewType = VkImageViewType::VK_IMAGE_VIEW_TYPE_2D;
+			}
+			break;
+		case GraphicsAPI::ImageDimension::Dimension3D:
 			imageViewType = VkImageViewType::VK_IMAGE_VIEW_TYPE_3D;
+			break;
+		case GraphicsAPI::ImageDimension::Invalid:
+			imageViewType = VkImageViewType::VK_IMAGE_VIEW_TYPE_MAX_ENUM;
+			break;
 		}
 	}
 

--- a/sources/code/Plugins/GraphicsVulkan/VulkanImage.hpp
+++ b/sources/code/Plugins/GraphicsVulkan/VulkanImage.hpp
@@ -35,6 +35,7 @@ namespace Grindstone::GraphicsAPI::Vulkan {
 		uint32_t depth;
 		uint32_t mipLevels;
 		uint32_t arrayLayers;
+		GraphicsAPI::ImageDimension imageDimension;
 		uint64_t maxImageSize;
 		GraphicsAPI::Format format;
 		Grindstone::Containers::BitsetFlags<GraphicsAPI::ImageUsageFlags> imageUsage;

--- a/sources/code/Plugins/Renderables3D/Mesh3dRenderer.cpp
+++ b/sources/code/Plugins/Renderables3D/Mesh3dRenderer.cpp
@@ -60,7 +60,7 @@ Grindstone::Mesh3dRenderer::Mesh3dRenderer(EngineCore* engineCore) {
 	descriptorSetUniformBinding.bindingId = 0;
 	descriptorSetUniformBinding.type = GraphicsAPI::BindingType::UniformBuffer;
 	descriptorSetUniformBinding.count = 1;
-	descriptorSetUniformBinding.stages = GraphicsAPI::ShaderStageBit::Vertex | GraphicsAPI::ShaderStageBit::Fragment;
+	descriptorSetUniformBinding.stages = GraphicsAPI::ShaderStageBit::Vertex;
 
 	GraphicsAPI::DescriptorSetLayout::CreateInfo descriptorSetLayoutCreateInfo{};
 	descriptorSetLayoutCreateInfo.debugName = "Per Draw Descriptor Set Layout";

--- a/sources/code/Plugins/RendererDeferred/DeferredRenderer.cpp
+++ b/sources/code/Plugins/RendererDeferred/DeferredRenderer.cpp
@@ -1352,7 +1352,7 @@ void DeferredRenderer::UpdateDescriptorSets(DeferredRendererImageSet& imageSet) 
 
 	{
 		GraphicsAPI::DescriptorSet::Binding blurredSsaoInputBinding = GraphicsAPI::DescriptorSet::Binding::SampledImage(imageSet.ambientOcclusionRenderTarget);
-		imageSet.blurredSsaoInputDescriptorSet->ChangeBindings(&blurredSsaoInputBinding, 1, 0);
+		imageSet.blurredSsaoInputDescriptorSet->ChangeBindings(&blurredSsaoInputBinding, 1, 1);
 	}
 }
 

--- a/sources/code/Plugins/RendererDeferred/DeferredRenderer.cpp
+++ b/sources/code/Plugins/RendererDeferred/DeferredRenderer.cpp
@@ -211,6 +211,10 @@ DeferredRenderer::~DeferredRenderer() {
 		graphicsCore->DeleteImage(imageSet.ambientOcclusionRenderTarget);
 		graphicsCore->DeleteFramebuffer(imageSet.ambientOcclusionFramebuffer);
 		graphicsCore->DeleteDescriptorSet(imageSet.ambientOcclusionDescriptorSet);
+
+		graphicsCore->DeleteImage(imageSet.blurredAmbientOcclusionRenderTarget);
+		graphicsCore->DeleteFramebuffer(imageSet.blurredAmbientOcclusionFramebuffer);
+		graphicsCore->DeleteDescriptorSet(imageSet.blurredSsaoInputDescriptorSet);
 	}
 
 	for (GraphicsAPI::Buffer* bloomUb : bloomUniformBuffers) {
@@ -220,6 +224,7 @@ DeferredRenderer::~DeferredRenderer() {
 	graphicsCore->DeleteDescriptorSetLayout(engineDescriptorSetLayout);
 	graphicsCore->DeleteDescriptorSetLayout(tonemapDescriptorSetLayout);
 	graphicsCore->DeleteDescriptorSetLayout(lightingDescriptorSetLayout);
+	graphicsCore->DeleteDescriptorSetLayout(blurredSsaoInputDescriptorSetLayout);
 
 	graphicsCore->DeleteBuffer(ssaoUniformBuffer);
 	graphicsCore->DeleteImage(ssaoNoiseTexture);
@@ -549,6 +554,10 @@ void DeferredRenderer::CreateSsaoKernelAndNoise() {
 			);
 			sample = glm::normalize(sample);
 			sample *= randomFloats(generator);
+
+			float scale = static_cast<float>(i) / static_cast<float>(ssaoKernelSize);
+			scale = 0.1f + (0.9f * scale * scale);
+			sample *= scale;
 			ssaoUboStruct.kernels[i] = sample;
 		}
 
@@ -697,6 +706,9 @@ void DeferredRenderer::Resize(uint32_t width, uint32_t height) {
 
 		imageSet.ambientOcclusionRenderTarget->Resize(halfWidth, halfHeight);
 		imageSet.ambientOcclusionFramebuffer->Resize(halfWidth, halfHeight);
+
+		imageSet.blurredAmbientOcclusionRenderTarget->Resize(halfWidth, halfHeight);
+		imageSet.blurredAmbientOcclusionFramebuffer->Resize(halfWidth, halfHeight);
 
 		CreateDepthOfFieldRenderTargetsAndDescriptorSets(imageSet, i);
 		CreateSsrRenderTargetsAndDescriptorSets(imageSet, i);
@@ -1172,6 +1184,25 @@ void DeferredRenderer::CreateDescriptorSetLayouts() {
 		ambientOcclusionInputLayoutCreateInfo.bindings = ambientOcclusionInputLayoutBinding.data();
 		ambientOcclusionDescriptorSetLayout = graphicsCore->CreateDescriptorSetLayout(ambientOcclusionInputLayoutCreateInfo);
 	}
+
+	{
+		std::array<GraphicsAPI::DescriptorSetLayout::Binding, 2> ambientOcclusionInputBlurLayoutBinding{};
+		ambientOcclusionInputBlurLayoutBinding[0].bindingId = 0;
+		ambientOcclusionInputBlurLayoutBinding[0].count = 1;
+		ambientOcclusionInputBlurLayoutBinding[0].type = GraphicsAPI::BindingType::Sampler;
+		ambientOcclusionInputBlurLayoutBinding[0].stages = GraphicsAPI::ShaderStageBit::Fragment;
+
+		ambientOcclusionInputBlurLayoutBinding[1].bindingId = 1;
+		ambientOcclusionInputBlurLayoutBinding[1].count = 1;
+		ambientOcclusionInputBlurLayoutBinding[1].type = GraphicsAPI::BindingType::SampledImage;
+		ambientOcclusionInputBlurLayoutBinding[1].stages = GraphicsAPI::ShaderStageBit::Fragment;
+
+		GraphicsAPI::DescriptorSetLayout::CreateInfo ambientOcclusionBlurInputLayoutCreateInfo{};
+		ambientOcclusionBlurInputLayoutCreateInfo.debugName = "Ambient Occlusion Blur Descriptor Set Layout";
+		ambientOcclusionBlurInputLayoutCreateInfo.bindingCount = static_cast<uint32_t>(ambientOcclusionInputBlurLayoutBinding.size());
+		ambientOcclusionBlurInputLayoutCreateInfo.bindings = ambientOcclusionInputBlurLayoutBinding.data();
+		blurredSsaoInputDescriptorSetLayout = graphicsCore->CreateDescriptorSetLayout(ambientOcclusionBlurInputLayoutCreateInfo);
+	}
 }
 
 void DeferredRenderer::CreateDescriptorSets(DeferredRendererImageSet& imageSet) {
@@ -1211,7 +1242,7 @@ void DeferredRenderer::CreateDescriptorSets(DeferredRendererImageSet& imageSet) 
 	debugDescriptorSetBindings[2] = gbufferAlbedoBinding;
 	debugDescriptorSetBindings[3] = gbufferNormalBinding;
 	debugDescriptorSetBindings[4] = gbufferSpecRoughnessBinding;
-	debugDescriptorSetBindings[5] = GraphicsAPI::DescriptorSet::Binding::SampledImage( imageSet.ambientOcclusionRenderTarget );
+	debugDescriptorSetBindings[5] = GraphicsAPI::DescriptorSet::Binding::SampledImage( imageSet.blurredAmbientOcclusionRenderTarget );
 	debugDescriptorSetBindings[6] = GraphicsAPI::DescriptorSet::Binding::UniformBuffer( imageSet.debugUniformBufferObject );
 
 	GraphicsAPI::DescriptorSet::CreateInfo debugDescriptorSetCreateInfo{};
@@ -1253,7 +1284,7 @@ void DeferredRenderer::CreateDescriptorSets(DeferredRendererImageSet& imageSet) 
 
 	{
 		std::array<GraphicsAPI::DescriptorSet::Binding, 3> aoInputBinding = {
-			GraphicsAPI::DescriptorSet::Binding::SampledImage( imageSet.ambientOcclusionRenderTarget ),
+			GraphicsAPI::DescriptorSet::Binding::SampledImage( imageSet.blurredAmbientOcclusionRenderTarget ),
 			GraphicsAPI::DescriptorSet::Binding::SampledImage( brdfLut.Get()->image ),
 			GraphicsAPI::DescriptorSet::Binding::SampledImage( nullptr )
 		};
@@ -1264,6 +1295,20 @@ void DeferredRenderer::CreateDescriptorSets(DeferredRendererImageSet& imageSet) 
 		aoInputCreateInfo.bindingCount = static_cast<uint32_t>(aoInputBinding.size());
 		aoInputCreateInfo.bindings = aoInputBinding.data();
 		imageSet.ambientOcclusionDescriptorSet = graphicsCore->CreateDescriptorSet(aoInputCreateInfo);
+	}
+
+	{
+		std::array<GraphicsAPI::DescriptorSet::Binding, 2> aoBlurInputBinding = {
+			screenSamplerBinding,
+			GraphicsAPI::DescriptorSet::Binding::SampledImage( imageSet.ambientOcclusionRenderTarget )
+		};
+
+		GraphicsAPI::DescriptorSet::CreateInfo aoBlurInputCreateInfo{};
+		aoBlurInputCreateInfo.debugName = "Ambient Occlusion Blur Descriptor Set";
+		aoBlurInputCreateInfo.layout = blurredSsaoInputDescriptorSetLayout;
+		aoBlurInputCreateInfo.bindingCount = static_cast<uint32_t>(aoBlurInputBinding.size());
+		aoBlurInputCreateInfo.bindings = aoBlurInputBinding.data();
+		imageSet.blurredSsaoInputDescriptorSet = graphicsCore->CreateDescriptorSet(aoBlurInputCreateInfo);
 	}
 }
 
@@ -1301,8 +1346,13 @@ void DeferredRenderer::UpdateDescriptorSets(DeferredRendererImageSet& imageSet) 
 	}
 
 	{
-		GraphicsAPI::DescriptorSet::Binding ssaoInputBinding = GraphicsAPI::DescriptorSet::Binding::SampledImage(imageSet.ambientOcclusionRenderTarget);
+		GraphicsAPI::DescriptorSet::Binding ssaoInputBinding = GraphicsAPI::DescriptorSet::Binding::SampledImage(imageSet.blurredAmbientOcclusionRenderTarget);
 		imageSet.ambientOcclusionDescriptorSet->ChangeBindings(&ssaoInputBinding, 1, 0);
+	}
+
+	{
+		GraphicsAPI::DescriptorSet::Binding blurredSsaoInputBinding = GraphicsAPI::DescriptorSet::Binding::SampledImage(imageSet.ambientOcclusionRenderTarget);
+		imageSet.blurredSsaoInputDescriptorSet->ChangeBindings(&blurredSsaoInputBinding, 1, 0);
 	}
 }
 
@@ -1436,6 +1486,29 @@ void DeferredRenderer::CreateGbufferFramebuffer() {
 			ssaoFramebufferCreateInfo.renderPass = engineCore.GetRenderPassRegistry()->GetRenderpass(ssaoRenderPassKey);
 			imageSet.ambientOcclusionFramebuffer = graphicsCore->CreateFramebuffer(ssaoFramebufferCreateInfo);
 		}
+
+		{
+			GraphicsAPI::Image::CreateInfo ssaoRenderTargetCreateInfo{};
+			ssaoRenderTargetCreateInfo.debugName = "Blurred SSAO Render Target";
+			ssaoRenderTargetCreateInfo.format = ambientOcclusionFormat;
+			ssaoRenderTargetCreateInfo.width = framebufferWidth / 2;
+			ssaoRenderTargetCreateInfo.height = framebufferHeight / 2;
+			ssaoRenderTargetCreateInfo.imageUsage =
+				GraphicsAPI::ImageUsageFlags::RenderTarget |
+				GraphicsAPI::ImageUsageFlags::Sampled;
+
+			imageSet.blurredAmbientOcclusionRenderTarget = graphicsCore->CreateImage(ssaoRenderTargetCreateInfo);
+
+			GraphicsAPI::Framebuffer::CreateInfo ssaoFramebufferCreateInfo{};
+			ssaoFramebufferCreateInfo.debugName = "Blurred SSAO Framebuffer";
+			ssaoFramebufferCreateInfo.width = framebufferWidth / 2;
+			ssaoFramebufferCreateInfo.height = framebufferHeight / 2;
+			ssaoFramebufferCreateInfo.renderTargets = &imageSet.blurredAmbientOcclusionRenderTarget;
+			ssaoFramebufferCreateInfo.renderTargetCount = 1;
+			ssaoFramebufferCreateInfo.depthTarget = nullptr;
+			ssaoFramebufferCreateInfo.renderPass = engineCore.GetRenderPassRegistry()->GetRenderpass(ssaoRenderPassKey);
+			imageSet.blurredAmbientOcclusionFramebuffer = graphicsCore->CreateFramebuffer(ssaoFramebufferCreateInfo);
+		}
 	}
 }
 
@@ -1481,6 +1554,7 @@ void DeferredRenderer::CreatePipelines() {
 	ssrPipelineSet = assetManager->GetAssetReferenceByAddress<ComputePipelineAsset>("@CORESHADERS/postProcessing/screenSpaceReflections");
 
 	ssaoPipelineSet = assetManager->GetAssetReferenceByAddress<GraphicsPipelineAsset>("@CORESHADERS/postProcessing/screenSpaceAmbientOcclusion");
+	ssaoBlurPipelineSet = assetManager->GetAssetReferenceByAddress<GraphicsPipelineAsset>("@CORESHADERS/postProcessing/screenSpaceAmbientOcclusionBlur");
 	imageBasedLightingPipelineSet = assetManager->GetAssetReferenceByAddress<GraphicsPipelineAsset>("@CORESHADERS/lighting/ibl");
 	pointLightPipelineSet = assetManager->GetAssetReferenceByAddress<GraphicsPipelineAsset>("@CORESHADERS/lighting/point");
 	spotLightPipelineSet = assetManager->GetAssetReferenceByAddress<GraphicsPipelineAsset>("@CORESHADERS/lighting/spot");
@@ -1895,13 +1969,15 @@ void DeferredRenderer::RenderLights(
 }
 
 void DeferredRenderer::RenderSsao(DeferredRendererImageSet& imageSet, GraphicsAPI::CommandBuffer* commandBuffer) {
-	Grindstone::GraphicsPipelineAsset* pipelineSetAsset = ssaoPipelineSet.Get();
-	if (pipelineSetAsset == nullptr) {
+	Grindstone::GraphicsPipelineAsset* ssaoPipelineSetAsset = ssaoPipelineSet.Get();
+	Grindstone::GraphicsPipelineAsset* blurPipelineSetAsset = ssaoBlurPipelineSet.Get();
+	if (ssaoPipelineSetAsset == nullptr || blurPipelineSetAsset == nullptr) {
 		return;
 	}
 
-	Grindstone::GraphicsAPI::GraphicsPipeline* ssaoPipeline = pipelineSetAsset->GetFirstPassPipeline(&vertexLightPositionLayout);
-	if (ssaoPipeline == nullptr) {
+	Grindstone::GraphicsAPI::GraphicsPipeline* ssaoPipeline = ssaoPipelineSetAsset->GetFirstPassPipeline(&vertexLightPositionLayout);
+	Grindstone::GraphicsAPI::GraphicsPipeline* blurPipeline = blurPipelineSetAsset->GetFirstPassPipeline(&vertexLightPositionLayout);
+	if (ssaoPipeline == nullptr || blurPipeline == nullptr) {
 		return;
 	}
 
@@ -1941,6 +2017,32 @@ void DeferredRenderer::RenderSsao(DeferredRendererImageSet& imageSet, GraphicsAP
 	
 	commandBuffer->BindGraphicsPipeline(ssaoPipeline);
 	commandBuffer->BindGraphicsDescriptorSet(ssaoPipeline, descriptorSets.data(), 0, static_cast<uint32_t>(descriptorSets.size()));
+	commandBuffer->DrawIndices(0, 6, 0, 1, 0);
+	commandBuffer->UnbindRenderPass();
+
+	commandBuffer->BindRenderPass(
+		engineCore.GetRenderPassRegistry()->GetRenderpass(ssaoBlurRenderPassKey),
+		imageSet.blurredAmbientOcclusionFramebuffer,
+		imageSet.blurredAmbientOcclusionFramebuffer->GetWidth(),
+		imageSet.blurredAmbientOcclusionFramebuffer->GetHeight(),
+		&clearColorAttachment,
+		1,
+		clearDepthStencil
+	);
+
+	commandBuffer->SetViewport(0.0f, 0.0f, static_cast<float>(halfWidth), static_cast<float>(halfHeight), 0.0f, 1.0f);
+	commandBuffer->SetScissor(0, 0, halfWidth, halfHeight);
+
+	commandBuffer->BindVertexBuffers(&vertexBuffer, 1);
+	commandBuffer->BindIndexBuffer(indexBuffer);
+
+	std::array<Grindstone::GraphicsAPI::DescriptorSet*, 2> blurDescriptorSets = {
+		imageSet.engineDescriptorSet,
+		imageSet.blurredSsaoInputDescriptorSet
+	};
+
+	commandBuffer->BindGraphicsPipeline(blurPipeline);
+	commandBuffer->BindGraphicsDescriptorSet(blurPipeline, blurDescriptorSets.data(), 0, static_cast<uint32_t>(blurDescriptorSets.size()));
 	commandBuffer->DrawIndices(0, 6, 0, 1, 0);
 	commandBuffer->UnbindRenderPass();
 }

--- a/sources/code/Plugins/RendererDeferred/DeferredRenderer.hpp
+++ b/sources/code/Plugins/RendererDeferred/DeferredRenderer.hpp
@@ -70,6 +70,8 @@ namespace Grindstone {
 
 			GraphicsAPI::Framebuffer* ambientOcclusionFramebuffer = nullptr;
 			GraphicsAPI::Image* ambientOcclusionRenderTarget = nullptr;
+			GraphicsAPI::Framebuffer* blurredAmbientOcclusionFramebuffer = nullptr;
+			GraphicsAPI::Image* blurredAmbientOcclusionRenderTarget = nullptr;
 
 			GraphicsAPI::Buffer* globalUniformBufferObject = nullptr;
 			GraphicsAPI::Buffer* debugUniformBufferObject = nullptr;
@@ -86,6 +88,7 @@ namespace Grindstone {
 			GraphicsAPI::DescriptorSet* dofNearBlurDescriptorSet = nullptr;
 			GraphicsAPI::DescriptorSet* dofFarBlurDescriptorSet = nullptr;
 			GraphicsAPI::DescriptorSet* dofCombineDescriptorSet = nullptr;
+			GraphicsAPI::DescriptorSet* blurredSsaoInputDescriptorSet = nullptr;
 
 			GraphicsAPI::DescriptorSet* ambientOcclusionDescriptorSet = nullptr;
 
@@ -175,6 +178,7 @@ namespace Grindstone {
 		GraphicsAPI::DescriptorSetLayout* ambientOcclusionDescriptorSetLayout = nullptr;
 		GraphicsAPI::DescriptorSetLayout* ssaoInputDescriptorSetLayout = nullptr;
 		GraphicsAPI::DescriptorSet* ssaoInputDescriptorSet = nullptr;
+		GraphicsAPI::DescriptorSetLayout* blurredSsaoInputDescriptorSetLayout = nullptr;
 
 		GraphicsAPI::VertexInputLayout vertexLightPositionLayout{};
 
@@ -199,6 +203,7 @@ namespace Grindstone {
 		GraphicsAPI::VertexArrayObject* planePostProcessVao = nullptr;
 
 		Grindstone::AssetReference<Grindstone::GraphicsPipelineAsset> ssaoPipelineSet;
+		Grindstone::AssetReference<Grindstone::GraphicsPipelineAsset> ssaoBlurPipelineSet;
 		Grindstone::AssetReference<Grindstone::GraphicsPipelineAsset> imageBasedLightingPipelineSet;
 		Grindstone::AssetReference<Grindstone::GraphicsPipelineAsset> spotLightPipelineSet;
 		Grindstone::AssetReference<Grindstone::GraphicsPipelineAsset> pointLightPipelineSet;

--- a/sources/code/Plugins/RendererDeferred/DeferredRendererCommon.hpp
+++ b/sources/code/Plugins/RendererDeferred/DeferredRendererCommon.hpp
@@ -16,6 +16,7 @@ static Grindstone::HashedString dofBlurAndCombinationRenderPassKey = "DofBlurAnd
 static Grindstone::HashedString lightingRenderPassKey = "Lighting";
 static Grindstone::HashedString forwardLitRenderPassKey = "ForwardLit";
 static Grindstone::HashedString ssaoRenderPassKey = "Ssao";
+static Grindstone::HashedString ssaoBlurRenderPassKey = "Ssao Blur";
 static Grindstone::HashedString shadowMapRenderPassKey = "ShadowMap";
 
 static const Grindstone::GraphicsAPI::Format depthFormat = Grindstone::GraphicsAPI::Format::D32_SFLOAT;

--- a/sources/code/Plugins/RendererDeferred/DeferredRendererFactory.cpp
+++ b/sources/code/Plugins/RendererDeferred/DeferredRendererFactory.cpp
@@ -64,6 +64,19 @@ static Grindstone::GraphicsAPI::RenderPass* CreateSsaoRenderPass(Grindstone::Gra
 	return rp;
 }
 
+static Grindstone::GraphicsAPI::RenderPass* CreateSsaoBlurRenderPass(Grindstone::GraphicsAPI::Core* graphicsCore, Grindstone::RenderPassRegistry* rpRegistry) {
+	GraphicsAPI::RenderPass::AttachmentInfo attachment{ ambientOcclusionFormat, true };
+	GraphicsAPI::RenderPass::CreateInfo ssaoRenderPassCreateInfo{};
+	ssaoRenderPassCreateInfo.debugName = "SSAO Blur Renderpass";
+	ssaoRenderPassCreateInfo.colorAttachments = &attachment;
+	ssaoRenderPassCreateInfo.colorAttachmentCount = 1;
+	ssaoRenderPassCreateInfo.depthFormat = GraphicsAPI::Format::Invalid;
+	ssaoRenderPassCreateInfo.shouldClearDepthOnLoad = false;
+	Grindstone::GraphicsAPI::RenderPass* rp = graphicsCore->CreateRenderPass(ssaoRenderPassCreateInfo);
+	rpRegistry->RegisterRenderpass(ssaoBlurRenderPassKey, rp);
+	return rp;
+}
+
 static Grindstone::GraphicsAPI::RenderPass* CreateGbufferRenderPass(Grindstone::GraphicsAPI::Core* graphicsCore, Grindstone::RenderPassRegistry* rpRegistry) {
 	const int gbufferColorCount = 3;
 	std::array<GraphicsAPI::RenderPass::AttachmentInfo, gbufferColorCount> gbufferColorAttachments{};
@@ -157,6 +170,7 @@ Grindstone::DeferredRendererFactory::DeferredRendererFactory() {
 	mainRenderpass = CreateMainRenderPass(graphicsCore, rpRegistry);
 	shadowMapRenderPass = CreateShadowMapRenderPass(graphicsCore, rpRegistry);
 	ssaoRenderPass = CreateSsaoRenderPass(graphicsCore, rpRegistry);
+	ssaoBlurRenderPass = CreateSsaoBlurRenderPass(graphicsCore, rpRegistry);
 	gbufferRenderpass = CreateGbufferRenderPass(graphicsCore, rpRegistry);
 }
 

--- a/sources/code/Plugins/RendererDeferred/DeferredRendererFactory.hpp
+++ b/sources/code/Plugins/RendererDeferred/DeferredRendererFactory.hpp
@@ -26,6 +26,7 @@ namespace Grindstone {
 		GraphicsAPI::RenderPass* lightingRenderPass = nullptr;
 		GraphicsAPI::RenderPass* forwardLitRenderPass = nullptr;
 		GraphicsAPI::RenderPass* ssaoRenderPass = nullptr;
+		GraphicsAPI::RenderPass* ssaoBlurRenderPass = nullptr;
 		GraphicsAPI::RenderPass* shadowMapRenderPass = nullptr;
 		GraphicsAPI::RenderPass* targetRenderPass = nullptr;
 		GraphicsAPI::RenderPass* mainRenderpass = nullptr;


### PR DESCRIPTION
Various graphics fixes
 - TextureImporter / Add support for BC5 textures
 - TextureImporter / Track ImageDimensions enum separately, as detecting this based off width/height/depth is complex
 - Post-Processing / Blur the SSAO pass
 - Image-Based Lighting / Fix issue of incorrect matrices for position
 - Image-Based Lighting / Fix f90 parameter, which gives better results
 - Tonemap / Remove linearToSRGB (not needed as we use SRGB image)
 - Tonemap / Fix f90 value not being set properly
 - SSAO / Set blur input binding properly